### PR TITLE
fix: edge-to-edge

### DIFF
--- a/app/src/main/java/org/monogram/app/MainActivity.kt
+++ b/app/src/main/java/org/monogram/app/MainActivity.kt
@@ -25,6 +25,8 @@ class MainActivity : FragmentActivity() {
     @OptIn(ExperimentalDecomposeApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
         root = retainedComponent { componentContext ->
             DefaultRootComponent(
                 DefaultAppComponentContext(
@@ -33,7 +35,6 @@ class MainActivity : FragmentActivity() {
                 )
             )
         }
-        enableEdgeToEdge()
 
         handleIntent(intent)
         startNotificationService()

--- a/app/src/main/java/org/monogram/app/ui/theme/Theme.kt
+++ b/app/src/main/java/org/monogram/app/ui/theme/Theme.kt
@@ -1,14 +1,17 @@
 package org.monogram.app.ui.theme
 
-import android.app.Activity
 import android.os.Build
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -135,11 +138,10 @@ fun MonoGramTheme(
         else -> LightColorScheme
     }
     val view = LocalView.current
+    val activity = LocalActivity.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.background.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            activity?.window?.let { WindowCompat.getInsetsController(it, view) }?.isAppearanceLightStatusBars = !darkTheme
         }
     }
 


### PR DESCRIPTION
Поправил поддержку Edge-to-Edge

На API ниже 35 был просто белый статус-бар, исправлено
Было: 
<img width="602" height="1246" alt="Screenshot_20260329_221225" src="https://github.com/user-attachments/assets/ca450d77-8c2d-468f-8a27-d6eb62c043fe" />

Стало:
<img width="602" height="1246" alt="изображение" src="https://github.com/user-attachments/assets/f536d90e-d98b-4c4c-922f-a1fd9920bd5a" />

