### PR TITLE
feature: session relative date

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -78,4 +78,6 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
+
+    testImplementation(libs.junit)
 }

--- a/data/src/main/java/org/monogram/data/mapper/SessionMapper.kt
+++ b/data/src/main/java/org/monogram/data/mapper/SessionMapper.kt
@@ -1,6 +1,7 @@
 package org.monogram.data.mapper
 
 import org.drinkless.tdlib.TdApi
+import org.monogram.data.utils.toDate
 import org.monogram.domain.models.SessionModel
 import org.monogram.domain.models.SessionType
 
@@ -16,7 +17,7 @@ fun TdApi.Session.toDomain(): SessionModel {
         platform = this.platform,
         systemVersion = this.systemVersion,
         logInDate = this.logInDate,
-        lastActiveDate = this.lastActiveDate,
+        lastActiveDate = this.lastActiveDate.toDate(),
         ipAddress = this.ipAddress,
         location = this.location,
         isOfficial = this.isOfficialApplication,

--- a/data/src/main/java/org/monogram/data/utils/DateUtils.kt
+++ b/data/src/main/java/org/monogram/data/utils/DateUtils.kt
@@ -1,0 +1,8 @@
+package org.monogram.data.utils
+
+import java.util.Date
+
+/**
+ * Map timestamp (in seconds) to [Date]
+ **/
+fun Int.toDate() = Date(this.toLong() * 1000L)

--- a/data/src/test/java/org/monogram/data/utils/DateUtilsTest.kt
+++ b/data/src/test/java/org/monogram/data/utils/DateUtilsTest.kt
@@ -1,0 +1,20 @@
+package org.monogram.data.utils
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+/**
+ * Test cases for date utils
+ **/
+class DateUtilsTest {
+
+    @Test
+    fun `When date in seconds is provided, then return same mills date`() {
+        val test = 1775228794
+        val actual = test.toDate().time
+        val expected = test * 1000L
+
+        assertEquals(/* expected = */ expected, /* actual = */ actual)
+    }
+
+}

--- a/domain/src/main/java/org/monogram/domain/models/SessionModel.kt
+++ b/domain/src/main/java/org/monogram/domain/models/SessionModel.kt
@@ -1,5 +1,10 @@
 package org.monogram.domain.models
 
+import java.util.Date
+
+private const val OCULUS = "OculusQuest"
+private const val CHROME = "Chrome"
+
 data class SessionModel(
     val id: Long,
     val isCurrent: Boolean,
@@ -11,12 +16,16 @@ data class SessionModel(
     val platform: String,
     val systemVersion: String,
     val logInDate: Int,
-    val lastActiveDate: Int,
+    val lastActiveDate: Date,
     val ipAddress: String,
     val location: String,
     val isOfficial: Boolean,
     val type: SessionType
-)
+) {
+    val isOculus: Boolean = type == SessionType.Android && deviceModel.contains(OCULUS, ignoreCase = true)
+
+    val isChrome : Boolean = type == SessionType.Chrome || deviceModel.contains(CHROME, ignoreCase = true)
+}
 
 enum class SessionType {
     Android, Apple, Brave, Chrome, Edge, Firefox,

--- a/presentation/src/main/java/org/monogram/presentation/core/ui/spacer/Spacer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/ui/spacer/Spacer.kt
@@ -1,0 +1,19 @@
+package org.monogram.presentation.core.ui.spacer
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Simple width spacer
+ *
+ * @param widthDp width in DP
+ **/
+@NonRestartableComposable
+@Composable
+fun WidthSpacer(widthDp: Dp) {
+    Spacer(modifier = Modifier.width(widthDp))
+}

--- a/presentation/src/main/java/org/monogram/presentation/core/util/DateUtils.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/util/DateUtils.kt
@@ -1,0 +1,61 @@
+package org.monogram.presentation.core.util
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToLong
+
+/**
+ * Formats date as relative string as for day, week, year, periods and so-on
+ *
+ * @param locale a [Locale] object which used with this date
+ * @param now optional current date (for custom formatting or testing)
+ **/
+fun Date.toShortRelativeDate(
+    locale: Locale = Locale.getDefault(),
+    now: Date = Date()
+): String {
+    val currentCalendar = Calendar.getInstance(locale).apply { time = now }
+    val targetCalendar = Calendar.getInstance(locale).apply { time = this@toShortRelativeDate }
+
+    val currentDayStart = currentCalendar.clone() as Calendar
+    currentDayStart.apply {
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+
+    val targetDayStart = targetCalendar.clone() as Calendar
+    targetDayStart.apply {
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+
+    val diffMillis = abs(currentDayStart.timeInMillis - targetDayStart.timeInMillis)
+
+    val diffDays = (diffMillis.toDouble() / (1000 * 60 * 60 * 24)).roundToLong()
+
+    return when (diffDays) {
+        0L -> {
+            SimpleDateFormat("HH:mm", locale).format(this)
+        }
+        in 1..6 -> {
+            SimpleDateFormat("EEE", locale).format(this)
+                .lowercase(locale)
+                .replace(".", "")
+        }
+        in 7..365 -> {
+            SimpleDateFormat("d MMM", locale).format(this)
+                .lowercase(locale)
+                .replace(".", "")
+        }
+        else -> {
+            SimpleDateFormat("dd.MM.yyyy", locale).format(this)
+        }
+    }
+}

--- a/presentation/src/main/java/org/monogram/presentation/settings/sessions/Mappers.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/sessions/Mappers.kt
@@ -1,0 +1,129 @@
+package org.monogram.presentation.settings.sessions
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Android
+import androidx.compose.material.icons.rounded.Language
+import androidx.compose.material.icons.rounded.Laptop
+import androidx.compose.material.icons.rounded.Terminal
+import androidx.compose.material.icons.rounded.VideogameAsset
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import org.monogram.domain.models.SessionModel
+import org.monogram.domain.models.SessionType
+import org.monogram.presentation.R
+import org.monogram.presentation.core.ui.ItemPosition
+
+/**
+ * Map session model to its own color
+ *
+ * @param isPending `true` if this session in Pending state
+ **/
+internal fun SessionModel.toBrandColor(
+    isPending: Boolean
+): Color {
+    if (isPending) return Color(0xFFF9AB00)
+    if (isOculus) return Color(0xFF000000)
+    if (isChrome) return Color(0xFF4285F4)
+
+    return when (type) {
+        SessionType.Android -> Color(0xFF34A853)
+        SessionType.Linux, SessionType.Ubuntu -> Color(0xFFFCC624)
+        SessionType.Apple, SessionType.Mac, SessionType.Iphone, SessionType.Ipad -> Color(0xFF000000)
+        SessionType.Windows -> Color(0xFF0078D7)
+        SessionType.Chrome -> Color(0xFF4285F4)
+        SessionType.Edge -> Color(0xFF0078D7)
+        SessionType.Firefox -> Color(0xFFE66000)
+        SessionType.Safari -> Color(0xFF007AFF)
+        SessionType.Opera -> Color(0xFFFF1B2D)
+        SessionType.Vivaldi -> Color(0xFFEF3939)
+        SessionType.Brave -> Color(0xFFFF1B2D)
+        SessionType.Xbox -> Color(0xFF107C10)
+        else -> Color(0xFF4285F4)
+    }
+}
+
+/**
+ * Map session model to its own logo
+ *
+ * @param isPending `true` if this session in Pending state
+ **/
+@Composable
+internal fun SessionModel.toLogo(
+    isPending: Boolean
+): Painter = when {
+    isPending -> rememberVectorPainter(Icons.Rounded.Warning)
+    isOculus -> painterResource(R.drawable.ic_oculus)
+    isChrome -> painterResource(R.drawable.ic_chrome)
+
+    type == SessionType.Android -> rememberVectorPainter(Icons.Rounded.Android)
+    type in listOf(
+        SessionType.Apple,
+        SessionType.Mac,
+        SessionType.Iphone,
+        SessionType.Ipad
+    ) -> painterResource(R.drawable.ic_apple)
+
+    type == SessionType.Windows -> painterResource(R.drawable.ic_windows)
+    type in listOf(SessionType.Linux, SessionType.Ubuntu) -> rememberVectorPainter(Icons.Rounded.Terminal)
+
+    type == SessionType.Chrome -> painterResource(R.drawable.ic_chrome)
+    type == SessionType.Xbox -> rememberVectorPainter(Icons.Rounded.VideogameAsset)
+
+    type in listOf(
+        SessionType.Firefox,
+        SessionType.Safari,
+        SessionType.Edge,
+        SessionType.Opera,
+        SessionType.Brave,
+        SessionType.Vivaldi
+    ) -> rememberVectorPainter(Icons.Rounded.Language)
+
+    else -> rememberVectorPainter(Icons.Rounded.Laptop)
+}
+
+/**
+ * Map session model to its own icon tint
+ *
+ * @param isPending `true` if this session in Pending state
+ * @param fallback a fallback color to show
+ **/
+internal fun SessionModel.toIconTint(
+    isPending: Boolean,
+    fallback: Color
+): Color {
+    return when {
+        isPending -> fallback
+        isOculus -> Color.Unspecified
+        isChrome -> Color.Unspecified
+        type == SessionType.Chrome -> Color.Unspecified
+        else -> fallback
+    }
+}
+
+internal fun ItemPosition.toShape(): RoundedCornerShape {
+    val cornerRadius = 24.dp
+    return when (this) {
+        ItemPosition.TOP -> RoundedCornerShape(
+            topStart = cornerRadius,
+            topEnd = cornerRadius,
+            bottomStart = 4.dp,
+            bottomEnd = 4.dp
+        )
+
+        ItemPosition.MIDDLE -> RoundedCornerShape(4.dp)
+        ItemPosition.BOTTOM -> RoundedCornerShape(
+            bottomStart = cornerRadius,
+            bottomEnd = cornerRadius,
+            topStart = 4.dp,
+            topEnd = 4.dp
+        )
+
+        ItemPosition.STANDALONE -> RoundedCornerShape(cornerRadius)
+    }
+}

--- a/presentation/src/main/java/org/monogram/presentation/settings/sessions/SessionItem.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/sessions/SessionItem.kt
@@ -1,180 +1,70 @@
 package org.monogram.presentation.settings.sessions
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Logout
-import androidx.compose.material.icons.rounded.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.rounded.Verified
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.monogram.domain.models.SessionModel
-import org.monogram.domain.models.SessionType
-import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.ItemPosition
-import java.text.SimpleDateFormat
-import java.util.*
+import org.monogram.presentation.core.ui.spacer.WidthSpacer
+import org.monogram.presentation.core.util.toShortRelativeDate
 
 @Composable
-fun SessionItem(
+internal fun SessionItem(
     session: SessionModel,
     isPending: Boolean = false,
     position: ItemPosition = ItemPosition.STANDALONE,
     onTerminate: (() -> Unit)?
 ) {
-    val isOculus = remember(session.type, session.deviceModel) {
-        session.type == SessionType.Android && session.deviceModel.contains("OculusQuest", ignoreCase = true)
-    }
-
-    val isChrome = remember(session.type, session.deviceModel) {
-        session.type == SessionType.Chrome || session.deviceModel.contains("Chrome", ignoreCase = true)
-    }
-
-    val brandColor = remember(session.type, isPending, isOculus) {
-        if (isPending) return@remember Color(0xFFF9AB00)
-        if (isOculus) return@remember Color(0xFF000000)
-        if (isChrome) return@remember Color(0xFF4285F4)
-
-        when (session.type) {
-            SessionType.Android -> Color(0xFF34A853)
-            SessionType.Linux, SessionType.Ubuntu -> Color(0xFFFCC624)
-            SessionType.Apple, SessionType.Mac, SessionType.Iphone, SessionType.Ipad -> Color(0xFF000000)
-            SessionType.Windows -> Color(0xFF0078D7)
-            SessionType.Chrome -> Color(0xFF4285F4)
-            SessionType.Edge -> Color(0xFF0078D7)
-            SessionType.Firefox -> Color(0xFFE66000)
-            SessionType.Safari -> Color(0xFF007AFF)
-            SessionType.Opera -> Color(0xFFFF1B2D)
-            SessionType.Vivaldi -> Color(0xFFEF3939)
-            SessionType.Brave -> Color(0xFFFF1B2D)
-            SessionType.Xbox -> Color(0xFF107C10)
-            else -> Color(0xFF4285F4)
-        }
-    }
-
-    val iconPainter: Painter = when {
-        isPending -> rememberVectorPainter(Icons.Rounded.Warning)
-        isOculus -> painterResource(R.drawable.ic_oculus)
-        isChrome -> painterResource(R.drawable.ic_chrome)
-
-        session.type == SessionType.Android -> rememberVectorPainter(Icons.Rounded.Android)
-        session.type in listOf(
-            SessionType.Apple,
-            SessionType.Mac,
-            SessionType.Iphone,
-            SessionType.Ipad
-        ) -> painterResource(R.drawable.ic_apple)
-
-        session.type == SessionType.Windows -> painterResource(R.drawable.ic_windows)
-        session.type in listOf(SessionType.Linux, SessionType.Ubuntu) -> rememberVectorPainter(Icons.Rounded.Terminal)
-
-        session.type == SessionType.Chrome -> painterResource(R.drawable.ic_chrome)
-        session.type == SessionType.Xbox -> rememberVectorPainter(Icons.Rounded.VideogameAsset)
-
-        session.type in listOf(
-            SessionType.Firefox,
-            SessionType.Safari,
-            SessionType.Edge,
-            SessionType.Opera,
-            SessionType.Brave,
-            SessionType.Vivaldi
-        ) -> rememberVectorPainter(Icons.Rounded.Language)
-
-        else -> rememberVectorPainter(Icons.Rounded.Laptop)
-    }
-
-    val cornerRadius = 24.dp
-    val shape = when (position) {
-        ItemPosition.TOP -> RoundedCornerShape(
-            topStart = cornerRadius,
-            topEnd = cornerRadius,
-            bottomStart = 4.dp,
-            bottomEnd = 4.dp
-        )
-
-        ItemPosition.MIDDLE -> RoundedCornerShape(4.dp)
-        ItemPosition.BOTTOM -> RoundedCornerShape(
-            bottomStart = cornerRadius,
-            bottomEnd = cornerRadius,
-            topStart = 4.dp,
-            topEnd = 4.dp
-        )
-
-        ItemPosition.STANDALONE -> RoundedCornerShape(cornerRadius)
-    }
-
     Surface(
         color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = shape,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(shape)
+        shape = position.toShape(),
+        modifier = Modifier.fillMaxWidth()
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .background(color = brandColor.copy(alpha = 0.15f), shape = CircleShape),
-                contentAlignment = Alignment.Center
-            ) {
-                val iconTint = when {
-                    isPending -> brandColor
-                    isOculus -> Color.Unspecified
-                    isChrome -> Color.Unspecified
-                    session.type == SessionType.Chrome -> Color.Unspecified
-                    else -> brandColor
-                }
+            PlatformIcon(
+                session = session,
+                isPending = isPending,
+            )
 
-                Icon(
-                    painter = iconPainter,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = iconTint
-                )
-            }
-
-            Spacer(modifier = Modifier.width(16.dp))
+            WidthSpacer(16.dp)
 
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.Center
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = if (isPending) "Попытка входа" else session.deviceModel,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontSize = 18.sp,
-                        fontWeight = if (isPending) FontWeight.Bold else FontWeight.Normal,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-
-                    if (session.isOfficial && !isPending) {
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Icon(
-                            imageVector = Icons.Rounded.Verified,
-                            contentDescription = "Official",
-                            modifier = Modifier.size(16.dp),
-                            tint = Color(0xFF31A6FD)
-                        )
-                    }
-                }
+                PlatformName(
+                    session = session,
+                    isPending = isPending,
+                )
 
                 Text(
                     text = if (isPending) "${session.deviceModel} • ${session.location}"
@@ -184,31 +74,81 @@ fun SessionItem(
                 )
 
                 Text(
-                    text = if (isPending) "Не подтверждено • ${convertTimestampToTimeLegacy(session.lastActiveDate.toLong())}"
-                    else "${session.location} • ${convertTimestampToTimeLegacy(session.lastActiveDate.toLong())}",
+                    text = if (isPending) "Не подтверждено • ${session.lastActiveDate.toShortRelativeDate()}"
+                    else "${session.location} •  ${session.lastActiveDate.toShortRelativeDate()}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                 )
             }
 
             if (onTerminate != null) {
-                IconButton(
-                    onClick = onTerminate,
-                    modifier = Modifier.padding(start = 8.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.Logout,
-                        contentDescription = "Terminate session",
-                        tint = MaterialTheme.colorScheme.error
-                    )
-                }
+                ExitButton(onClick = onTerminate)
             }
         }
     }
 }
 
-private fun convertTimestampToTimeLegacy(timestamp: Long): String {
-    val date = Date(timestamp)
-    val format = SimpleDateFormat("HH:mm", Locale.getDefault())
-    return format.format(date)
+@Composable
+private fun PlatformIcon(
+    session: SessionModel,
+    isPending: Boolean,
+) {
+    val brandColor = remember { session.toBrandColor(isPending) }
+    val iconPainter = session.toLogo(isPending)
+
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .background(color = brandColor.copy(alpha = 0.15f), shape = CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = iconPainter,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = session.toIconTint(isPending = isPending, fallback = brandColor)
+        )
+    }
+}
+
+@Composable
+private fun PlatformName(
+    session: SessionModel,
+    isPending: Boolean,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = if (isPending) "Попытка входа" else session.deviceModel,
+            style = MaterialTheme.typography.titleMedium,
+            fontSize = 18.sp,
+            fontWeight = if (isPending) FontWeight.Bold else FontWeight.Normal,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        if (session.isOfficial && !isPending) {
+            Spacer(modifier = Modifier.width(6.dp))
+            Icon(
+                imageVector = Icons.Rounded.Verified,
+                contentDescription = "Official",
+                modifier = Modifier.size(16.dp),
+                tint = Color(0xFF31A6FD)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExitButton(
+    onClick: () -> Unit
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.padding(start = 8.dp)
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Rounded.Logout,
+            contentDescription = "Terminate session",
+            tint = MaterialTheme.colorScheme.error
+        )
+    }
 }

--- a/presentation/src/test/java/org/monogram/presentation/core/util/DateUtilsTest.kt
+++ b/presentation/src/test/java/org/monogram/presentation/core/util/DateUtilsTest.kt
@@ -1,0 +1,63 @@
+package org.monogram.presentation.core.util
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Test cases for date utils
+ **/
+class DateUtilsTest {
+    private val ruLocale = Locale.forLanguageTag("ru")
+    private val dateFormatter = SimpleDateFormat("dd.MM.yyyy HH:mm", ruLocale)
+    private val mockToday: Date = dateFormatter.parse("20.03.2024 12:00")!!
+
+    @Test
+    fun `When date are today, then returns only hours and minutes`() {
+        val targetDate = dateFormatter.parse("20.03.2024 15:20")!!
+        val result = targetDate.toShortRelativeDate(locale = ruLocale, now = mockToday)
+
+        assertEquals("15:20", result)
+    }
+
+    @Test
+    fun `When date are yesterday and within 1 week, then returns day of week`() {
+        // Yesterday
+        val yesterday = dateFormatter.parse("19.03.2024 10:15")!!
+        assertEquals("вт", yesterday.toShortRelativeDate(locale = ruLocale, now = mockToday))
+
+        // Six days ago
+        val sixDaysAgo = dateFormatter.parse("14.03.2024 09:00")!!
+        assertEquals("чт", sixDaysAgo.toShortRelativeDate(locale = ruLocale, now = mockToday))
+    }
+
+    @Test
+    fun `When date are older than 1 week but within 1 year, then return day and month`() {
+        // 13.03.2024 - ровно 7 дней назад
+        val sevenDaysAgo = dateFormatter.parse("13.03.2024 14:00")!!
+        assertEquals("13 мар", sevenDaysAgo.toShortRelativeDate(locale = ruLocale, now = mockToday))
+
+        // Прошлый месяц (меньше 365 дней назад)
+        val monthsAgo = dateFormatter.parse("25.10.2023 18:30")!!
+        assertEquals("25 окт", monthsAgo.toShortRelativeDate(locale = ruLocale, now = mockToday))
+    }
+
+    @Test
+    fun `When date are older than 1 year, then return full date`() {
+        // Past year
+        val olderThanYear = dateFormatter.parse("10.03.2023 11:11")!!
+        assertEquals("10.03.2023", olderThanYear.toShortRelativeDate(locale = ruLocale, now = mockToday))
+
+        // A long time ago...
+        val veryOldDate = dateFormatter.parse("01.01.2020 00:00")!!
+        assertEquals("01.01.2020", veryOldDate.toShortRelativeDate(locale = ruLocale, now = mockToday))
+    }
+
+    @Test
+    fun `Then future date is older than 1 year, then return full date`() {
+        val futureDate = dateFormatter.parse("16.03.2029 10:00")!!
+        assertEquals("16.03.2029", futureDate.toShortRelativeDate(locale = ruLocale, now = mockToday))
+    }
+}


### PR DESCRIPTION
- Сделал время последней сессии более понятным (относительным: 12:12, чт, пт, 15 мар, 28.02.2022)
- Немного отрефачил ячейку сессии, сделал её более читаемой

<img width="599" height="1266" alt="Screenshot_20260403_230218" src="https://github.com/user-attachments/assets/ee32014b-88be-4bab-bc17-01780d821ebb" />

