### PR TITLE
feat: use `CompositionLocal` for `VideoPlayerPool`

### DIFF
--- a/app/src/main/java/org/monogram/app/MainActivity.kt
+++ b/app/src/main/java/org/monogram/app/MainActivity.kt
@@ -14,6 +14,7 @@ import org.monogram.app.ui.theme.AppThemeContainer
 import org.monogram.data.service.TdNotificationService
 import org.monogram.domain.repository.AppPreferencesProvider
 import org.monogram.domain.repository.PushProvider
+import org.monogram.presentation.core.util.LocalVideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.chats.LocalLinkHandler
 import org.monogram.presentation.root.DefaultAppComponentContext
 import org.monogram.presentation.root.DefaultRootComponent
@@ -42,7 +43,10 @@ class MainActivity : FragmentActivity() {
 
         setContent {
             AppThemeContainer(root.appPreferences) {
-                CompositionLocalProvider(LocalLinkHandler provides root::handleLink) {
+                CompositionLocalProvider(
+                LocalLinkHandler provides root::handleLink,
+                        LocalVideoPlayerPool provides root.videoPlayerPool
+                ) {
                     MainContent(root)
                 }
             }

--- a/app/src/main/java/org/monogram/app/components/ChatConfirmJoinSheet.kt
+++ b/app/src/main/java/org/monogram/app/components/ChatConfirmJoinSheet.kt
@@ -51,8 +51,7 @@ fun ChatConfirmJoinSheet(root: RootComponent) {
                     path = avatarPath,
                     name = title,
                     size = 100.dp,
-                    fontSize = 32,
-                    videoPlayerPool = root.videoPlayerPool,
+                    fontSize = 32
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/org/monogram/app/di/AppModule.kt
+++ b/app/src/main/java/org/monogram/app/di/AppModule.kt
@@ -33,7 +33,7 @@ val appModule = module {
 
     single { ExoPlayerCache() }
     single { CacheController(androidContext(), get()) }
-    single { VideoPlayerPool(androidContext(), get()) }
+    single { VideoPlayerPool(androidContext(), get(), get()) }
     single<ClipManager> {
         ClipManagerImpl(
             androidContext().getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager,

--- a/presentation/src/main/java/org/monogram/presentation/core/ui/Avatar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/ui/Avatar.kt
@@ -24,7 +24,6 @@ import coil3.request.ImageRequest
 import org.monogram.presentation.R
 import org.monogram.presentation.core.util.generateColorFromHash
 import org.monogram.presentation.features.chats.currentChat.components.AvatarPlayer
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import java.io.File
 
 @Composable
@@ -33,7 +32,6 @@ fun Avatar(
     fallbackPath: String? = null,
     name: String,
     size: Dp,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier,
     fontSize: Int = 14,
     isOnline: Boolean = false,
@@ -74,8 +72,7 @@ fun Avatar(
                         AvatarPlayer(
                             path = resolvedPath,
                             modifier = combinedModifier,
-                            contentScale = ContentScale.Crop,
-                            videoPlayerPool = videoPlayerPool
+                            contentScale = ContentScale.Crop
                         )
                     }
                 } else {
@@ -126,8 +123,7 @@ fun AvatarForChat(
     modifier: Modifier = Modifier,
     fontSize: Int = 14,
     isOnline: Boolean = false,
-    isLocal: Boolean = false,
-    videoPlayerPool: VideoPlayerPool
+    isLocal: Boolean = false
 ) {
     val context = LocalContext.current
     val combinedModifier = modifier
@@ -162,8 +158,7 @@ fun AvatarForChat(
                         AvatarPlayer(
                             path = resolvedPath,
                             modifier = combinedModifier,
-                            contentScale = ContentScale.Crop,
-                            videoPlayerPool = videoPlayerPool
+                            contentScale = ContentScale.Crop
                         )
                     }
                 } else {
@@ -232,7 +227,7 @@ private fun resolveAvatarPath(primaryPath: String?, fallbackPath: String?): Stri
     if (candidates.isEmpty()) return null
 
     val existingCandidates = candidates.filter { File(it).exists() }
-    val source = if (existingCandidates.isNotEmpty()) existingCandidates else candidates
+    val source = existingCandidates.ifEmpty { candidates }
 
     return source.firstOrNull { it.endsWith(".mp4", ignoreCase = true) } ?: source.firstOrNull()
 }

--- a/presentation/src/main/java/org/monogram/presentation/core/ui/AvatarHeader.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/ui/AvatarHeader.kt
@@ -23,20 +23,18 @@ import coil3.size.Precision
 import coil3.size.Size
 import org.monogram.presentation.core.util.generateColorFromHash
 import org.monogram.presentation.features.chats.currentChat.components.AvatarPlayer
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import java.io.File
 
 @Composable
 fun AvatarHeader(
     path: String?,
-    fallbackPath: String? = null,
     name: String,
     size: Dp,
     modifier: Modifier = Modifier,
+    fallbackPath: String? = null,
     fontSize: Int = 64,
     isOnline: Boolean = false,
-    avatarCornerPercent: Int = 0,
-    videoPlayerPool: VideoPlayerPool
+    avatarCornerPercent: Int = 0
 ) {
     val context = LocalContext.current
     val combinedModifier = modifier
@@ -56,8 +54,7 @@ fun AvatarHeader(
                     AvatarPlayer(
                         path = resolvedPath,
                         modifier = Modifier.matchParentSize(),
-                        contentScale = ContentScale.Crop,
-                        videoPlayerPool = videoPlayerPool
+                        contentScale = ContentScale.Crop
                     )
                 }
 
@@ -98,7 +95,7 @@ private fun resolveAvatarPath(primaryPath: String?, fallbackPath: String?): Stri
     if (candidates.isEmpty()) return null
 
     val existingCandidates = candidates.filter { File(it).exists() }
-    val source = if (existingCandidates.isNotEmpty()) existingCandidates else candidates
+    val source = existingCandidates.ifEmpty { candidates }
 
     return source.firstOrNull { it.endsWith(".mp4", ignoreCase = true) } ?: source.firstOrNull()
 }

--- a/presentation/src/main/java/org/monogram/presentation/core/ui/UserProfileHeader.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/ui/UserProfileHeader.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.monogram.domain.models.UserModel
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
 
 @Composable
@@ -38,7 +37,6 @@ fun UserProfileHeader(
     contentPadding: PaddingValues,
     currentRadius: Dp,
     alpha: Float = 1f,
-    videoPlayerPool: VideoPlayerPool,
     onStatusClick: (() -> Unit)? = null,
     onStatusBoundsChanged: ((Rect) -> Unit)? = null
 ) {
@@ -61,8 +59,7 @@ fun UserProfileHeader(
                     fallbackPath = userModel.personalAvatarPath,
                     name = "${userModel.firstName} ${userModel.lastName}",
                     size = avatarSize.coerceAtMost(headerHeight),
-                    avatarCornerPercent = avatarCornerPercent,
-                    videoPlayerPool = videoPlayerPool
+                    avatarCornerPercent = avatarCornerPercent
                 )
             }
 

--- a/presentation/src/main/java/org/monogram/presentation/core/util/CompositionLocal.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/util/CompositionLocal.kt
@@ -1,0 +1,8 @@
+package org.monogram.presentation.core.util
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
+
+val LocalVideoPlayerPool = staticCompositionLocalOf<VideoPlayerPool> {
+    error("VideoPlayerPool not provided")
+}

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/ChatListComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/ChatListComponent.kt
@@ -4,11 +4,9 @@ import kotlinx.coroutines.flow.StateFlow
 import org.monogram.domain.models.*
 import org.monogram.domain.repository.ConnectionStatus
 import org.monogram.presentation.core.util.AppPreferences
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface ChatListComponent {
     val state: StateFlow<State>
-    val videoPlayerPool: VideoPlayerPool
     val appPreferences: AppPreferences
 
     fun onChatClicked(id: Long)

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/ChatListContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/ChatListContent.kt
@@ -387,8 +387,7 @@ fun ChatListContent(component: ChatListComponent) {
                     botUserId = bot.botUserId,
                     botName = state.botWebAppName ?: bot.name
                 )
-            },
-            videoPlayerPool = component.videoPlayerPool
+            }
         )
     }
 
@@ -524,8 +523,7 @@ fun ChatListContent(component: ChatListComponent) {
                                     statusAnchorBounds = anchorBounds ?: statusAnchorBounds
                                     showStatusMenu = true
                                 },
-                                onMenuClick = { showAccountMenu = true },
-                                videoPlayerPool = component.videoPlayerPool
+                                onMenuClick = { showAccountMenu = true }
                             )
                         }
                     }
@@ -818,8 +816,7 @@ fun ChatListContent(component: ChatListComponent) {
                                                         fallbackPath = chat.personalAvatarPath,
                                                         name = chat.title,
                                                         size = 64.dp,
-                                                        isOnline = chat.isOnline,
-                                                        videoPlayerPool = component.videoPlayerPool
+                                                        isOnline = chat.isOnline
                                                     )
                                                     Box(
                                                         modifier = Modifier
@@ -866,8 +863,7 @@ fun ChatListContent(component: ChatListComponent) {
                                         onLongClick = { component.onRemoveSearchHistoryItem(chat.id) },
                                         emojiFontFamily = emojiFontFamily,
                                         messageLines = messageLines,
-                                        showPhotos = showPhotos,
-                                        videoPlayerPool = component.videoPlayerPool
+                                        showPhotos = showPhotos
                                     )
                                 }
                             }
@@ -892,8 +888,7 @@ fun ChatListContent(component: ChatListComponent) {
                                     onLongClick = { onChatLongClicked(chat.id) },
                                     emojiFontFamily = emojiFontFamily,
                                     messageLines = messageLines,
-                                    showPhotos = showPhotos,
-                                    videoPlayerPool = component.videoPlayerPool
+                                    showPhotos = showPhotos
                                 )
                             }
                         }
@@ -921,8 +916,7 @@ fun ChatListContent(component: ChatListComponent) {
                                     onLongClick = { onChatLongClicked(chat.id) },
                                     emojiFontFamily = emojiFontFamily,
                                     messageLines = messageLines,
-                                    showPhotos = showPhotos,
-                                    videoPlayerPool = component.videoPlayerPool
+                                    showPhotos = showPhotos
                                 )
                             }
 
@@ -968,8 +962,7 @@ fun ChatListContent(component: ChatListComponent) {
                                 MessageSearchItem(
                                     modifier = Modifier.animateItem(),
                                     message = msg,
-                                    onClick = { component.onMessageClicked(msg.chatId, msg.id) },
-                                    videoPlayerPool = component.videoPlayerPool
+                                    onClick = { component.onMessageClicked(msg.chatId, msg.id) }
                                 )
                             }
 
@@ -1009,8 +1002,7 @@ fun ChatListContent(component: ChatListComponent) {
                                     isTabletSelected = isTablet && state.activeChatId == chat.id,
                                     emojiFontFamily = emojiFontFamily,
                                     messageLines = messageLines,
-                                    showPhotos = showPhotos,
-                                    videoPlayerPool = component.videoPlayerPool
+                                    showPhotos = showPhotos
                                 )
                             }
                         }
@@ -1134,7 +1126,6 @@ fun ChatListContent(component: ChatListComponent) {
                                             onClick = { onChatClicked(chat.id) },
                                             onLongClick = { onChatLongClicked(chat.id) },
                                             isTabletSelected = isTablet && state.activeChatId == chat.id,
-                                            videoPlayerPool = component.videoPlayerPool,
                                             emojiFontFamily = emojiFontFamily,
                                             messageLines = messageLines,
                                             showPhotos = showPhotos
@@ -1260,8 +1251,7 @@ fun ChatListContent(component: ChatListComponent) {
                 url = url,
                 messageRepository = koinInject(),
                 onDismiss = { component.onDismissInstantView() },
-                onOpenWebView = { component.onOpenWebView(it) },
-                videoPlayerPool = component.videoPlayerPool
+                onOpenWebView = { component.onOpenWebView(it) }
             )
         }
     }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/DefaultChatListComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/DefaultChatListComponent.kt
@@ -22,7 +22,6 @@ import org.monogram.presentation.core.util.componentScope
 import org.monogram.presentation.features.chats.ChatListComponent
 import org.monogram.presentation.features.chats.ChatListStore
 import org.monogram.presentation.features.chats.ChatListStoreFactory
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultChatListComponent(
@@ -43,7 +42,6 @@ class DefaultChatListComponent(
     private val settingsRepository: SettingsRepository = container.repositories.settingsRepository
     private val updateRepository: UpdateRepository = container.repositories.updateRepository
     override val appPreferences: AppPreferences = container.preferences.appPreferences
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state = MutableStateFlow(
         ChatListComponent.State(

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/AccountMenu.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/AccountMenu.kt
@@ -93,19 +93,15 @@ import org.monogram.domain.models.UserModel
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.ui.ItemPosition
-import com.google.i18n.phonenumbers.PhoneNumberUtil
-import org.koin.compose.koinInject
 import org.monogram.presentation.core.ui.SettingsItem
 import org.monogram.presentation.core.util.AppUtils
 import org.monogram.presentation.core.util.CountryManager
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AccountMenu(
     user: UserModel?,
-    videoPlayerPool: VideoPlayerPool,
     attachMenuBots: List<AttachMenuBotModel>,
     updateState: UpdateState = UpdateState.Idle,
     onDismiss: () -> Unit,
@@ -314,8 +310,7 @@ fun AccountMenu(
                                     isPhoneVisible = isExpanded
                                 },
                                 isPhoneVisible = isPhoneVisible,
-                                onPhoneToggle = { isPhoneVisible = !isPhoneVisible },
-                                videoPlayerPool = videoPlayerPool
+                                onPhoneToggle = { isPhoneVisible = !isPhoneVisible }
                             )
 
                             AnimatedVisibility(
@@ -527,7 +522,6 @@ private fun MenuHeader(onDismiss: () -> Unit) {
 @Composable
 private fun ActiveAccountCard(
     user: UserModel?,
-    videoPlayerPool: VideoPlayerPool,
     isExpanded: Boolean,
     onExpandToggle: () -> Unit,
     isPhoneVisible: Boolean,
@@ -575,8 +569,7 @@ private fun ActiveAccountCard(
                 fallbackPath = user?.personalAvatarPath,
                 name = user?.firstName ?: "",
                 size = 56.dp,
-                fontSize = 20,
-                videoPlayerPool = videoPlayerPool
+                fontSize = 20
             )
 
             Spacer(modifier = Modifier.width(16.dp))

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/Avatar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/Avatar.kt
@@ -23,7 +23,6 @@ import coil3.compose.rememberAsyncImagePainter
 import coil3.request.ImageRequest
 import org.monogram.presentation.core.util.generateColorFromHash
 import org.monogram.presentation.features.chats.currentChat.components.AvatarPlayer
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import java.io.File
 
 @Composable
@@ -32,7 +31,6 @@ fun AvatarTopAppBar(
     fallbackPath: String? = null,
     name: String,
     size: Dp,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier,
     fontSize: Int = 14,
     isOnline: Boolean = false
@@ -52,8 +50,7 @@ fun AvatarTopAppBar(
                     AvatarPlayer(
                         path = resolvedPath,
                         modifier = combinedModifier,
-                        contentScale = ContentScale.Crop,
-                        videoPlayerPool = videoPlayerPool
+                        contentScale = ContentScale.Crop
                     )
                 }
             } else {

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/ChatListItem.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/ChatListItem.kt
@@ -34,7 +34,6 @@ import org.monogram.domain.models.MessageEntityType
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.AvatarForChat
 import org.monogram.presentation.core.ui.TypingDots
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.chats.addEmojiStyle
 import org.monogram.presentation.features.chats.currentChat.components.chats.buildAnnotatedMessageTextWithEmoji
 import org.monogram.presentation.features.chats.currentChat.components.chats.rememberMessageInlineContent
@@ -51,7 +50,6 @@ fun ChatListItem(
     emojiFontFamily: FontFamily,
     messageLines: Int,
     showPhotos: Boolean,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier,
     isTabletSelected: Boolean = false
 ) {
@@ -87,8 +85,7 @@ fun ChatListItem(
                 ChatListItemAvatar(
                     chat = chat,
                     isSavedMessages = isSavedMessages,
-                    isSelected = isSelected,
-                    videoPlayerPool = videoPlayerPool
+                    isSelected = isSelected
                 )
 
                 Spacer(Modifier.width(14.dp))
@@ -109,8 +106,7 @@ fun ChatListItem(
 private fun ChatListItemAvatar(
     chat: ChatModel,
     isSavedMessages: Boolean,
-    isSelected: Boolean,
-    videoPlayerPool: VideoPlayerPool
+    isSelected: Boolean
 ) {
     Box(contentAlignment = Alignment.Center) {
         AnimatedVisibility(
@@ -157,8 +153,7 @@ private fun ChatListItemAvatar(
                         fallbackPath = chat.personalAvatarPath,
                         name = chat.title,
                         size = 56.dp,
-                        isOnline = chat.isOnline,
-                        videoPlayerPool = videoPlayerPool
+                        isOnline = chat.isOnline
                     )
                 }
             }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/ChatListTopBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/ChatListTopBar.kt
@@ -28,7 +28,6 @@ import org.monogram.domain.models.UserModel
 import org.monogram.domain.repository.ConnectionStatus
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.ExpressiveDefaults
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
 
 
@@ -36,7 +35,6 @@ import org.monogram.presentation.features.stickers.ui.view.StickerImage
 @Composable
 fun ChatListTopBar(
     user: UserModel?,
-    videoPlayerPool: VideoPlayerPool,
     connectionStatus: ConnectionStatus?,
     isProxyEnabled: Boolean,
     onRetryConnection: () -> Unit,
@@ -282,8 +280,7 @@ fun ChatListTopBar(
                                 path = user?.avatarPath,
                                 fallbackPath = user?.personalAvatarPath,
                                 name = user?.firstName ?: "",
-                                size = 36.dp,
-                                videoPlayerPool = videoPlayerPool
+                                size = 36.dp
                             )
                         }
                     }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/MessageSearchItem.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/MessageSearchItem.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.unit.dp
 import org.monogram.domain.models.MessageContent
 import org.monogram.domain.models.MessageModel
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -21,7 +20,6 @@ import java.util.*
 fun MessageSearchItem(
     message: MessageModel,
     onClick: () -> Unit,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier
 ) {
     val date = Date(message.date.toLong() * 1000)
@@ -50,8 +48,7 @@ fun MessageSearchItem(
             path = message.senderAvatar,
             fallbackPath = message.senderPersonalAvatar,
             name = message.senderName,
-            size = 48.dp,
-            videoPlayerPool = videoPlayerPool
+            size = 48.dp
         )
 
         Spacer(Modifier.width(14.dp))

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/NewChannelContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/NewChannelContent.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.core.ui.ItemPosition
 import org.monogram.presentation.core.ui.SettingsItem
 
@@ -38,7 +37,6 @@ fun NewChannelContent(
     onDescriptionChange: (String) -> Unit,
     onPhotoClick: () -> Unit,
     onAutoDeleteTimeChange: (Int) -> Unit,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier
 ) {
     var showAutoDeleteSheet by remember { mutableStateOf(false) }
@@ -61,8 +59,7 @@ fun NewChannelContent(
             ChannelPhotoSelector(
                 photoPath = photoPath,
                 title = title,
-                onClick = onPhotoClick,
-                videoPlayerPool = videoPlayerPool
+                onClick = onPhotoClick
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
@@ -148,7 +145,6 @@ fun NewChannelContent(
 @Composable
 private fun ChannelPhotoSelector(
     photoPath: String?,
-    videoPlayerPool: VideoPlayerPool,
     title: String,
     onClick: () -> Unit
 ) {
@@ -172,8 +168,7 @@ private fun ChannelPhotoSelector(
                 Avatar(
                     path = photoPath,
                     name = title,
-                    size = 100.dp,
-                    videoPlayerPool = videoPlayerPool
+                    size = 100.dp
                 )
             } else {
                 Icon(

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/NewGroupContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/chatList/components/NewGroupContent.kt
@@ -26,7 +26,6 @@ import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.ui.ItemPosition
 import org.monogram.presentation.core.ui.SettingsItem
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @Composable
 fun NewGroupContent(
@@ -38,7 +37,6 @@ fun NewGroupContent(
     onDescriptionChange: (String) -> Unit,
     onPhotoClick: () -> Unit,
     onAutoDeleteTimeChange: (Int) -> Unit,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier
 ) {
     var showAutoDeleteSheet by remember { mutableStateOf(false) }
@@ -61,8 +59,7 @@ fun NewGroupContent(
             GroupPhotoSelector(
                 photoPath = photoPath,
                 title = title,
-                onClick = onPhotoClick,
-                videoPlayerPool = videoPlayerPool
+                onClick = onPhotoClick
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
@@ -148,7 +145,6 @@ fun NewGroupContent(
 @Composable
 private fun GroupPhotoSelector(
     photoPath: String?,
-    videoPlayerPool: VideoPlayerPool,
     title: String,
     onClick: () -> Unit
 ) {
@@ -172,8 +168,7 @@ private fun GroupPhotoSelector(
                 Avatar(
                     path = photoPath,
                     name = title,
-                    size = 100.dp,
-                    videoPlayerPool = videoPlayerPool
+                    size = 100.dp
                 )
             } else {
                 Icon(

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/ChatComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/ChatComponent.kt
@@ -9,13 +9,11 @@ import org.monogram.domain.repository.MessageRepository
 import org.monogram.domain.repository.StickerRepository
 import org.monogram.presentation.core.util.AppPreferences
 import org.monogram.presentation.core.util.IDownloadUtils
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import java.io.File
 
 @Stable
 interface ChatComponent {
     val appPreferences: AppPreferences
-    val videoPlayerPool: VideoPlayerPool
     val stickerRepository: StickerRepository
     val state: StateFlow<State>
     val repositoryMessage: MessageRepository

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/ChatContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/ChatContent.kt
@@ -635,7 +635,6 @@ fun ChatContent(
                                 state = inputBarState,
                                 actions = inputBarActions,
                                 appPreferences = component.appPreferences,
-                                videoPlayerPool = component.videoPlayerPool,
                                 stickerRepository = component.stickerRepository
                             )
                         } else if (!state.isMember && (state.isChannel || state.isGroup)) {
@@ -818,7 +817,6 @@ fun ChatContent(
                                         it.let { component.toProfile(it) }
                                     },
                                     downloadUtils = component.downloadUtils,
-                                    videoPlayerPool = component.videoPlayerPool,
                                     isAnyViewerOpen = isAnyViewerOpen
                                 )
 
@@ -946,8 +944,7 @@ fun ChatContent(
                     onUnpin = { component.onUnpinMessage(it) },
                     onReplyClick = { scrollToMessageState.value(it); component.onDismissPinnedMessages() },
                     onReactionClick = { id, r -> component.onSendReaction(id, r) },
-                    downloadUtils = component.downloadUtils,
-                    videoPlayerPool = component.videoPlayerPool
+                    downloadUtils = component.downloadUtils
                 )
             }
 
@@ -967,8 +964,7 @@ fun ChatContent(
                         component.onDismissVoters()
                         component.toProfile(it)
                     },
-                    onDismiss = { component.onDismissVoters() },
-                    videoPlayerPool = component.videoPlayerPool
+                    onDismiss = { component.onDismissVoters() }
                 )
             }
 

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/DefaultChatComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/DefaultChatComponent.kt
@@ -48,7 +48,6 @@ import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.AppPreferences
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.impl.loadChatInfo
 import org.monogram.presentation.features.chats.currentChat.impl.loadDraft
 import org.monogram.presentation.features.chats.currentChat.impl.loadMessages
@@ -86,7 +85,6 @@ class DefaultChatComponent(
     override val repositoryMessage: MessageRepository = container.repositories.messageRepository
     override val appPreferences: AppPreferences = container.preferences.appPreferences
     internal val cacheProvider: CacheProvider = container.cacheProvider
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
     internal val cacheController: CacheController = container.utils.cacheController
     internal val distrManager: DistrManager = container.utils.distrManager()
     internal val dispatcherProvider: DispatcherProvider = container.utils.dispatcherProvider

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentList.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentList.kt
@@ -60,25 +60,24 @@ import java.io.File
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ChatContentList(
-    showNavPadding: Boolean = false,
     state: ChatComponent.State,
     component: ChatComponent,
     scrollState: LazyListState,
     groupedMessages: List<GroupedMessageItem>,
     onPhotoClick: (MessageModel, List<String>, List<String?>, List<Long>, Int) -> Unit,
     onPhotoDownload: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    showNavPadding: Boolean = false,
     onVideoClick: (MessageModel, String?, String?) -> Unit,
     onDocumentClick: (MessageModel) -> Unit,
     onAudioClick: (MessageModel) -> Unit,
     onMessageOptionsClick: (MessageModel, Offset, IntSize, Offset) -> Unit,
     onGoToReply: (MessageModel) -> Unit,
-    modifier: Modifier = Modifier,
     selectedMessageId: Long? = null,
     onMessagePositionChange: (Offset, IntSize) -> Unit = { _, _ -> },
     onViaBotClick: (String) -> Unit = {},
     toProfile: (Long) -> Unit,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val isComments = state.rootMessage != null
@@ -131,8 +130,7 @@ fun ChatContentList(
         TopicsList(
             topics = state.topics,
             onTopicClick = { component.onTopicClick(it.id) },
-            modifier = modifier,
-            videoPlayerPool = component.videoPlayerPool
+            modifier = modifier
         )
         return
     }
@@ -173,7 +171,6 @@ fun ChatContentList(
                         onViaBotClick,
                         toProfile,
                         downloadUtils,
-                        videoPlayerPool,
                         isAnyViewerOpen = isAnyViewerOpen
                     )
                 }
@@ -212,7 +209,6 @@ fun ChatContentList(
                     toProfile = toProfile,
                     isScrolling = isScrolling,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
             }
@@ -243,7 +239,6 @@ fun ChatContentList(
                         onViaBotClick,
                         toProfile,
                         downloadUtils,
-                        videoPlayerPool,
                         isAnyViewerOpen = isAnyViewerOpen
                     )
                 }
@@ -281,7 +276,6 @@ fun ChatContentList(
                     toProfile = toProfile,
                     isScrolling = isScrolling,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
             }
@@ -361,7 +355,6 @@ private fun MessageRowItem(
     toProfile: (Long) -> Unit,
     isScrolling: Boolean,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val mainMsg = remember(item) {
@@ -461,7 +454,6 @@ private fun MessageRowItem(
                     onViaBotClick = onViaBotClick,
                     toProfile = toProfile,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
             }
@@ -489,7 +481,6 @@ private fun MessageBubbleSwitcher(
     onViaBotClick: (String) -> Unit,
     toProfile: (Long) -> Unit,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val isChannel = state.isChannel && state.currentTopicId == null
@@ -593,7 +584,6 @@ private fun MessageBubbleSwitcher(
                     onYouTubeClick = { component.onOpenYouTube(it) },
                     onInstantViewClick = { component.onOpenInstantView(it) },
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
             } else {
@@ -698,7 +688,6 @@ private fun MessageBubbleSwitcher(
                     onReplySwipe = { component.onReplyMessage(it) },
                     swipeEnabled = !isSelectionMode,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
             }
@@ -767,7 +756,6 @@ private fun MessageBubbleSwitcher(
                 onReplySwipe = { component.onReplyMessage(it) },
                 swipeEnabled = !isSelectionMode,
                 downloadUtils = downloadUtils,
-                videoPlayerPool = videoPlayerPool,
                 isAnyViewerOpen = isAnyViewerOpen
             )
         }
@@ -811,7 +799,6 @@ private fun RootMessageSection(
     onViaBotClick: (String) -> Unit,
     toProfile: (Long) -> Unit,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val root = state.rootMessage ?: return
@@ -850,7 +837,6 @@ private fun RootMessageSection(
                 onYouTubeClick = { component.onOpenYouTube(it) },
                 onInstantViewClick = { component.onOpenInstantView(it) },
                 downloadUtils = downloadUtils,
-                videoPlayerPool = videoPlayerPool,
                 isAnyViewerOpen = isAnyViewerOpen
             )
         } else {
@@ -883,7 +869,6 @@ private fun RootMessageSection(
                 onInstantViewClick = { component.onOpenInstantView(it) },
                 onYouTubeClick = { component.onOpenYouTube(it) },
                 downloadUtils = downloadUtils,
-                videoPlayerPool = videoPlayerPool,
                 isAnyViewerOpen = isAnyViewerOpen
             )
         }
@@ -1037,7 +1022,6 @@ private fun MessageModel.mediaCaption(): String? {
 @Composable
 fun TopicsList(
     topics: List<TopicModel>,
-    videoPlayerPool: VideoPlayerPool,
     onTopicClick: (TopicModel) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -1051,7 +1035,7 @@ fun TopicsList(
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         itemsIndexed(sortedTopics, key = { _, topic -> topic.id }) { _, topic ->
-            TopicItem(topic = topic, videoPlayerPool = videoPlayerPool, onClick = { onTopicClick(topic) })
+            TopicItem(topic = topic, onClick = { onTopicClick(topic) })
         }
     }
 }
@@ -1059,7 +1043,6 @@ fun TopicsList(
 @Composable
 fun TopicItem(
     topic: TopicModel,
-    videoPlayerPool: VideoPlayerPool,
     onClick: () -> Unit
 ) {
     Surface(
@@ -1128,8 +1111,7 @@ fun TopicItem(
                             path = topic.lastMessageSenderAvatar,
                             name = topic.lastMessageSenderName ?: "",
                             size = 18.dp,
-                            fontSize = 8,
-                            videoPlayerPool = videoPlayerPool
+                            fontSize = 8
                         )
                         Spacer(modifier = Modifier.width(6.dp))
                     }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentTopBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentTopBar.kt
@@ -335,8 +335,7 @@ fun ChatContentTopBar(
                         { component.onProfileClicked() }
                     } else null,
                     showBack = showBack,
-                    personalAvatarPath = state.chatPersonalAvatar,
-                    videoPlayerPool = component.videoPlayerPool
+                    personalAvatarPath = state.chatPersonalAvatar
                 )
             }
         }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentViewers.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentViewers.kt
@@ -45,8 +45,7 @@ fun ChatContentViewers(
                 url = url,
                 messageRepository = component.repositoryMessage,
                 onDismiss = { component.onDismissInstantView() },
-                onOpenWebView = { component.onOpenWebView(it) },
-                videoPlayerPool = component.videoPlayerPool
+                onOpenWebView = { component.onOpenWebView(it) }
             )
         }
     }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatMessageOptionsMenu.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatMessageOptionsMenu.kt
@@ -252,7 +252,6 @@ fun ChatMessageOptionsMenu(
             scope.launch { reloadViewers() }
         },
         onViewerClick = { component.toProfile(it) },
-        videoPlayerPool = component.videoPlayerPool,
         bubbleRadius = state.bubbleRadius,
         splitOffset = splitOffset,
         onReply = {

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/AlbumMessageBubbleContainer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/AlbumMessageBubbleContainer.kt
@@ -61,7 +61,6 @@ fun AlbumMessageBubbleContainer(
     onReplySwipe: (MessageModel) -> Unit = {},
     swipeEnabled: Boolean = true,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     if (messages.isEmpty()) return
@@ -133,8 +132,7 @@ fun AlbumMessageBubbleContainer(
                     fallbackPath = firstMsg.senderPersonalAvatar,
                     name = firstMsg.senderName,
                     size = 40.dp,
-                    onClick = { toProfile(firstMsg.senderId) },
-                    videoPlayerPool = videoPlayerPool
+                    onClick = { toProfile(firstMsg.senderId) }
                 )
                 Spacer(modifier = Modifier.width(8.dp))
             }
@@ -193,7 +191,6 @@ fun AlbumMessageBubbleContainer(
                         fontSize = fontSize,
                         bubbleRadius = bubbleRadius,
                         downloadUtils = downloadUtils,
-                        videoPlayerPool = videoPlayerPool,
                         isAnyViewerOpen = isAnyViewerOpen
                     )
                 } else {
@@ -227,7 +224,6 @@ fun AlbumMessageBubbleContainer(
                         modifier = Modifier,
                         fontSize = fontSize,
                         downloadUtils = downloadUtils,
-                        videoPlayerPool = videoPlayerPool,
                         isAnyViewerOpen = isAnyViewerOpen
                     )
                 }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/AlphaVideoPlayer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/AlphaVideoPlayer.kt
@@ -58,6 +58,8 @@ import coil3.video.VideoFrameDecoder
 import coil3.video.videoFrameMillis
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import org.monogram.domain.repository.PlayerDataSourceFactory
+import org.monogram.presentation.core.util.LocalVideoPlayerPool
 import org.monogram.presentation.core.util.getMimeType
 import java.io.File
 import java.io.FileNotFoundException
@@ -83,7 +85,6 @@ sealed interface VideoType {
 @Composable
 fun VideoStickerPlayer(
     path: String,
-    videoPlayerPool: VideoPlayerPool,
     type: VideoType,
     modifier: Modifier = Modifier,
     animate: Boolean = true,
@@ -99,6 +100,8 @@ fun VideoStickerPlayer(
         Box(modifier = modifier)
         return
     }
+
+    val videoPlayerPool = LocalVideoPlayerPool.current
 
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -271,15 +274,13 @@ fun VideoStickerPlayer(
 }
 
 @OptIn(UnstableApi::class)
-class VideoPlayerPool(val context: Context, val exoPlayerCache: ExoPlayerCache) {
+class VideoPlayerPool(val context: Context, val exoPlayerCache: ExoPlayerCache, val streamingRepository: PlayerDataSourceFactory) {
     private val players = ArrayBlockingQueue<ExoPlayer>(8)
     private var isCallbackRegistered = false
     private var mediaSourceFactory: MediaSource.Factory? = null
 
     fun getMediaSourceFactory(fileId: Int = 0): MediaSource.Factory {
         if (fileId != 0) {
-            val streamingRepository =
-                org.koin.core.context.GlobalContext.get().get<org.monogram.domain.repository.PlayerDataSourceFactory>()
             val dataSourceFactory = streamingRepository.createPayload(fileId) as DataSource.Factory
             val extractorsFactory = DefaultExtractorsFactory()
                 .setConstantBitrateSeekingEnabled(true)
@@ -342,8 +343,6 @@ class VideoPlayerPool(val context: Context, val exoPlayerCache: ExoPlayerCache) 
             .setMp4ExtractorFlags(Mp4Extractor.FLAG_WORKAROUND_IGNORE_EDIT_LISTS)
 
         val mediaSourceFactory = if (fileId != 0) {
-            val streamingRepository =
-                org.koin.core.context.GlobalContext.get().get<org.monogram.domain.repository.PlayerDataSourceFactory>()
             val dataSourceFactory = streamingRepository.createPayload(fileId) as DataSource.Factory
             DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
         } else {

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/AvatarPlayer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/AvatarPlayer.kt
@@ -28,6 +28,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.video.VideoFrameDecoder
 import coil3.video.videoFrameMillis
+import org.monogram.presentation.core.util.LocalVideoPlayerPool
 import java.io.File
 
 @OptIn(UnstableApi::class)
@@ -35,13 +36,13 @@ import java.io.File
 fun AvatarPlayer(
     path: String,
     modifier: Modifier = Modifier,
-    contentScale: ContentScale = ContentScale.Crop,
-    videoPlayerPool: VideoPlayerPool
+    contentScale: ContentScale = ContentScale.Crop
 ) {
     if (LocalInspectionMode.current) {
         Box(modifier = modifier)
         return
     }
+    val videoPlayerPool = LocalVideoPlayerPool.current
 
     val context = LocalContext.current
     var isVideoFrameReady by remember { mutableStateOf(false) }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/ChannelMessageBubbleContainer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/ChannelMessageBubbleContainer.kt
@@ -62,8 +62,7 @@ fun ChannelMessageBubbleContainer(
     showComments: Boolean = true,
     toProfile: (Long) -> Unit = {},
     onViaBotClick: (String) -> Unit = {},
-    downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool
+    downloadUtils: IDownloadUtils
 ) {
     val configuration = LocalConfiguration.current
     val screenWidth = configuration.screenWidthDp.dp
@@ -185,8 +184,7 @@ fun ChannelMessageBubbleContainer(
                             onReplyClick = onGoToReply,
                             onReactionClick = { onReactionClick(msg.id, it) },
                             modifier = bubbleModifier.fillMaxWidth(),
-                            downloadUtils = downloadUtils,
-                            videoPlayerPool = videoPlayerPool
+                            downloadUtils = downloadUtils
                         )
                     }
 
@@ -260,8 +258,7 @@ fun ChannelMessageBubbleContainer(
                             onReplyClick = onGoToReply,
                             onReactionClick = { onReactionClick(msg.id, it) },
                             modifier = bubbleModifier.fillMaxWidth(),
-                            downloadUtils = downloadUtils,
-                            videoPlayerPool = videoPlayerPool
+                            downloadUtils = downloadUtils
                         )
                     }
 

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/ChatInputBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/ChatInputBar.kt
@@ -94,7 +94,6 @@ fun ChatInputBar(
     state: ChatInputBarState,
     actions: ChatInputBarActions,
     appPreferences: AppPreferences,
-    videoPlayerPool: VideoPlayerPool,
     stickerRepository: StickerRepository
 ) {
     if (state.isClosed) {
@@ -471,7 +470,6 @@ fun ChatInputBar(
                 isVideoMessageMode = isVideoMessageMode,
                 replyMarkup = state.replyMarkup,
                 showSendOptionsSheet = showSendOptionsSheet,
-                videoPlayerPool = videoPlayerPool,
                 stickerRepository = stickerRepository,
                 onCancelEdit = actions.onCancelEdit,
                 onCancelReply = actions.onCancelReply,
@@ -600,7 +598,6 @@ fun ChatInputBar(
                 isOverMessageLimit = isOverMessageLimit,
                 currentMessageLength = currentMessageLength,
                 maxMessageLength = maxMessageLength,
-                videoPlayerPool = videoPlayerPool,
                 stickerRepository = stickerRepository,
                 isPremiumUser = state.isPremiumUser,
                 isSecretChat = state.isSecretChat,

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/ChatTopBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/ChatTopBar.kt
@@ -44,7 +44,6 @@ fun ChatTopBar(
     avatarPath: String?,
     emojiStatusPath: String?,
     statusText: String?,
-    videoPlayerPool: VideoPlayerPool,
     isOnline: Boolean = false,
     isVerified: Boolean = false,
     isSponsor: Boolean = false,
@@ -139,8 +138,7 @@ fun ChatTopBar(
                                     fallbackPath = personalAvatarPath,
                                     name = title,
                                     size = 40.dp,
-                                    isOnline = isOnline,
-                                    videoPlayerPool = videoPlayerPool
+                                    isOnline = isOnline
                                 )
                             }
                             Spacer(Modifier.width(12.dp))

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/CompactMediaMosaic.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/CompactMediaMosaic.kt
@@ -62,7 +62,6 @@ fun CompactMediaMosaic(
     sendingState: MessageSendingState? = null,
     autoDownloadMobile: Boolean = false,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     autoDownloadWifi: Boolean = false,
     autoDownloadRoaming: Boolean = false,
     toProfile: (Long) -> Unit = {},
@@ -113,7 +112,6 @@ fun CompactMediaMosaic(
                         autoDownloadRoaming = autoDownloadRoaming,
                         modifier = Modifier.fillMaxSize(),
                         downloadUtils = downloadUtils,
-                        videoPlayerPool = videoPlayerPool,
                         isAnyViewerOpen = isAnyViewerOpen
                     )
                 }
@@ -132,7 +130,6 @@ fun CompactMediaMosaic(
                         autoDownloadRoaming = autoDownloadRoaming,
                         modifier = Modifier.fillMaxSize(),
                         downloadUtils = downloadUtils,
-                        videoPlayerPool = videoPlayerPool,
                         isAnyViewerOpen = isAnyViewerOpen
                     )
                 }
@@ -151,7 +148,6 @@ fun CompactMediaMosaic(
                         autoDownloadRoaming = autoDownloadRoaming,
                         modifier = Modifier.fillMaxSize(),
                         downloadUtils = downloadUtils,
-                        videoPlayerPool = videoPlayerPool,
                         isAnyViewerOpen = isAnyViewerOpen
                     )
                 }
@@ -417,7 +413,6 @@ fun VideoItem(
     modifier: Modifier = Modifier,
     contentScale: ContentScale = ContentScale.Crop,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     var stablePath by remember(msg.id) { mutableStateOf(video.path) }
@@ -475,7 +470,6 @@ fun VideoItem(
                             },
                         animate = !isAnyViewerOpen,
                         contentScale = contentScale,
-                        videoPlayerPool = videoPlayerPool,
                         fileId = if (stablePath == null) video.fileId else 0,
                         thumbnailData = video.minithumbnail
                     )
@@ -599,7 +593,6 @@ fun VideoItem(
 @Composable
 fun VideoNoteItem(
     msg: MessageModel,
-    videoPlayerPool: VideoPlayerPool,
     videoNote: MessageContent.VideoNote,
     autoplayVideos: Boolean,
     onVideoClick: (MessageModel) -> Unit,
@@ -662,7 +655,6 @@ fun VideoNoteItem(
                             },
                         animate = !isAnyViewerOpen,
                         contentScale = contentScale,
-                        videoPlayerPool = videoPlayerPool,
                         thumbnailData = videoNote.thumbnail
                     )
                 } else {
@@ -775,7 +767,6 @@ fun GifItem(
     modifier: Modifier = Modifier,
     contentScale: ContentScale = ContentScale.Crop,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     var stablePath by remember(msg.id) { mutableStateOf(gif.path) }
@@ -831,7 +822,6 @@ fun GifItem(
                         },
                     animate = autoplayGifs && !isAnyViewerOpen,
                     contentScale = contentScale,
-                    videoPlayerPool = videoPlayerPool,
                     thumbnailData = gif.minithumbnail
                 )
 
@@ -925,10 +915,10 @@ fun TimestampPill(
     time: String,
     isRead: Boolean,
     isOutgoing: Boolean,
+    modifier: Modifier = Modifier,
     isChannel: Boolean = false,
     views: Int? = null,
-    sendingState: MessageSendingState? = null,
-    modifier: Modifier = Modifier
+    sendingState: MessageSendingState? = null
 ) {
     val context = LocalContext.current
     Box(

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/MessageBubbleContainer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/MessageBubbleContainer.kt
@@ -74,7 +74,6 @@ fun MessageBubbleContainer(
     onReplySwipe: (MessageModel) -> Unit = {},
     swipeEnabled: Boolean = true,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val configuration = LocalConfiguration.current
@@ -150,8 +149,7 @@ fun MessageBubbleContainer(
                 isGroup = isGroup,
                 isOutgoing = isOutgoing,
                 isSameSenderBelow = isSameSenderBelow,
-                toProfile = toProfile,
-                videoPlayerPool = videoPlayerPool
+                toProfile = toProfile
             )
 
             Column(
@@ -205,7 +203,6 @@ fun MessageBubbleContainer(
                     bubblePosition = bubblePosition,
                     bubbleSize = bubbleSize,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
 
@@ -228,7 +225,6 @@ fun MessageBubbleContainer(
 @Composable
 private fun MessageAvatar(
     msg: MessageModel,
-    videoPlayerPool: VideoPlayerPool,
     isGroup: Boolean,
     isOutgoing: Boolean,
     isSameSenderBelow: Boolean,
@@ -242,8 +238,7 @@ private fun MessageAvatar(
                 name = msg.senderName,
                 size = 40.dp,
                 isLocal = msg.senderAvatar?.contains("local") ?: false,
-                onClick = { toProfile(msg.senderId) },
-                videoPlayerPool = videoPlayerPool)
+                onClick = { toProfile(msg.senderId) })
         } else {
             Spacer(modifier = Modifier.width(40.dp))
         }
@@ -290,7 +285,6 @@ private fun MessageContentSelector(
     bubblePosition: Offset,
     bubbleSize: IntSize,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     Column(
@@ -401,7 +395,6 @@ private fun MessageContentSelector(
                     toProfile = toProfile,
                     modifier = Modifier.fillMaxWidth(),
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
             }
@@ -481,7 +474,6 @@ private fun MessageContentSelector(
                     onReactionClick = { onReactionClick(msg.id, it) },
                     toProfile = toProfile,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
             }
@@ -565,7 +557,6 @@ private fun MessageContentSelector(
                     },
                     onReplyClick = onGoToReply,
                     onReactionClick = { onReactionClick(msg.id, it) },
-                    videoPlayerPool = videoPlayerPool,
                     toProfile = toProfile,
                     showReactions = msg.reactions.isNotEmpty()
                 )

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelAlbumMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelAlbumMessageBubble.kt
@@ -29,37 +29,35 @@ import org.monogram.domain.models.MessageContent
 import org.monogram.domain.models.MessageModel
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.components.CompactMediaMosaic
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.chats.*
 
 @Composable
 fun ChannelAlbumMessageBubble(
     messages: List<MessageModel>,
-    isSameSenderAbove: Boolean = false,
-    isSameSenderBelow: Boolean = false,
     autoplayGifs: Boolean,
     autoplayVideos: Boolean,
+    modifier: Modifier = Modifier,
+    fontSize: Float,
+    onPhotoClick: (MessageModel) -> Unit,
+    onLongClick: (Offset) -> Unit,
+    downloadUtils: IDownloadUtils,
+    isSameSenderAbove: Boolean = false,
+    isSameSenderBelow: Boolean = false,
     autoDownloadMobile: Boolean = false,
     autoDownloadWifi: Boolean = false,
     autoDownloadRoaming: Boolean = false,
     autoDownloadFiles: Boolean = false,
-    fontSize: Float,
     bubbleRadius: Float = 16f,
-    onPhotoClick: (MessageModel) -> Unit,
     onDownloadPhoto: (Int) -> Unit = {},
     onVideoClick: (MessageModel) -> Unit,
     onDocumentClick: (MessageModel) -> Unit = {},
     onAudioClick: (MessageModel) -> Unit = {},
     onCancelDownload: (Int) -> Unit = {},
-    onLongClick: (Offset) -> Unit,
     onReplyClick: (MessageModel) -> Unit = {},
     onReactionClick: (String) -> Unit = {},
     onCommentsClick: (Long) -> Unit = {},
     showComments: Boolean = true,
     toProfile: (Long) -> Unit = {},
-    modifier: Modifier = Modifier,
-    downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     if (messages.isEmpty()) return
@@ -113,8 +111,7 @@ fun ChannelAlbumMessageBubble(
             onCommentsClick = onCommentsClick,
             showComments = showComments,
             toProfile = toProfile,
-            modifier = modifier,
-            downloadUtils = downloadUtils
+            modifier = modifier
         )
         return
     }
@@ -212,7 +209,6 @@ fun ChannelAlbumMessageBubble(
                     autoDownloadRoaming = autoDownloadRoaming,
                     toProfile = toProfile,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
 
@@ -508,8 +504,7 @@ fun ChannelAudioAlbumBubble(
     onCommentsClick: (Long) -> Unit,
     showComments: Boolean,
     toProfile: (Long) -> Unit,
-    modifier: Modifier = Modifier,
-    downloadUtils: IDownloadUtils
+    modifier: Modifier = Modifier
 ) {
     val firstMsg = messages.first()
     val lastMsg = messages.last()

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelGifMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelGifMessageBubble.kt
@@ -35,7 +35,6 @@ import org.monogram.domain.models.MessageModel
 import org.monogram.domain.models.MessageSendingState
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.AutoDownloadSuppression
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.VideoStickerPlayer
 import org.monogram.presentation.features.chats.currentChat.components.VideoType
 import org.monogram.presentation.features.chats.currentChat.components.chats.*
@@ -44,15 +43,17 @@ import org.monogram.presentation.features.chats.currentChat.components.chats.*
 fun ChannelGifMessageBubble(
     content: MessageContent.Gif,
     msg: MessageModel,
-    isSameSenderAbove: Boolean = false,
-    isSameSenderBelow: Boolean = false,
     fontSize: Float,
     letterSpacing: Float,
-    bubbleRadius: Float = 18f,
     autoDownloadMobile: Boolean,
     autoDownloadWifi: Boolean,
     autoDownloadRoaming: Boolean,
     autoplayGifs: Boolean,
+    downloadUtils: IDownloadUtils,
+    modifier: Modifier = Modifier,
+    bubbleRadius: Float = 18f,
+    isSameSenderAbove: Boolean = false,
+    isSameSenderBelow: Boolean = false,
     onGifClick: (MessageModel) -> Unit = {},
     onCancelDownload: (Int) -> Unit = {},
     onLongClick: (Offset) -> Unit,
@@ -63,9 +64,6 @@ fun ChannelGifMessageBubble(
     showMetadata: Boolean = true,
     showReactions: Boolean = true,
     toProfile: (Long) -> Unit = {},
-    modifier: Modifier = Modifier,
-    downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val context = LocalContext.current
@@ -188,7 +186,6 @@ fun ChannelGifMessageBubble(
                                         modifier = Modifier.fillMaxSize(),
                                         contentScale = ContentScale.Fit,
                                         animate = !isAnyViewerOpen,
-                                        videoPlayerPool = videoPlayerPool,
                                         thumbnailData = content.minithumbnail
                                     )
                                 }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelMessageBubbleContainer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelMessageBubbleContainer.kt
@@ -27,7 +27,6 @@ import org.monogram.domain.models.MessageContent
 import org.monogram.domain.models.MessageModel
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.chatContent.shouldShowDate
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.chats.*
 
 @Composable
@@ -72,7 +71,6 @@ fun ChannelMessageBubbleContainer(
     toProfile: (Long) -> Unit = {},
     onViaBotClick: (String) -> Unit = {},
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val configuration = LocalConfiguration.current
@@ -238,7 +236,6 @@ fun ChannelMessageBubbleContainer(
                             toProfile = toProfile,
                             modifier = Modifier.fillMaxWidth(),
                             downloadUtils = downloadUtils,
-                            videoPlayerPool = videoPlayerPool,
                             isAnyViewerOpen = isAnyViewerOpen
                         )
                     }
@@ -332,7 +329,6 @@ fun ChannelMessageBubbleContainer(
                             toProfile = toProfile,
                             modifier = Modifier.fillMaxWidth(),
                             downloadUtils = downloadUtils,
-                            videoPlayerPool = videoPlayerPool,
                             isAnyViewerOpen = isAnyViewerOpen
                         )
                     }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelVideoMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/channels/ChannelVideoMessageBubble.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
@@ -40,7 +41,6 @@ import org.monogram.domain.models.MessageContent
 import org.monogram.domain.models.MessageModel
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.AutoDownloadSuppression
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.VideoStickerPlayer
 import org.monogram.presentation.features.chats.currentChat.components.VideoType
 import org.monogram.presentation.features.chats.currentChat.components.chats.*
@@ -49,15 +49,16 @@ import org.monogram.presentation.features.chats.currentChat.components.chats.*
 fun ChannelVideoMessageBubble(
     content: MessageContent.Video,
     msg: MessageModel,
-    isSameSenderAbove: Boolean = false,
-    isSameSenderBelow: Boolean = false,
     fontSize: Float,
     letterSpacing: Float,
-    bubbleRadius: Float = 18f,
     autoDownloadMobile: Boolean,
     autoDownloadWifi: Boolean,
     autoDownloadRoaming: Boolean,
     autoplayVideos: Boolean,
+    modifier: Modifier = Modifier,
+    bubbleRadius: Float = 18f,
+    isSameSenderBelow: Boolean = false,
+    isSameSenderAbove: Boolean = false,
     onVideoClick: (MessageModel) -> Unit,
     onCancelDownload: (Int) -> Unit = {},
     onLongClick: (Offset) -> Unit,
@@ -68,9 +69,7 @@ fun ChannelVideoMessageBubble(
     showMetadata: Boolean = true,
     showReactions: Boolean = true,
     toProfile: (Long) -> Unit = {},
-    modifier: Modifier = Modifier,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val cornerRadius = bubbleRadius.dp
@@ -95,7 +94,8 @@ fun ChannelVideoMessageBubble(
     var isVisible by remember { mutableStateOf(false) }
 
     val context = LocalContext.current
-    val screenHeightPx = remember { context.resources.displayMetrics.heightPixels }
+    val resource = LocalResources.current
+    val screenHeightPx = remember { resource.displayMetrics.heightPixels }
     val revealedSpoilers = remember { mutableStateListOf<Int>() }
 
     var stablePath by remember(msg.id) { mutableStateOf(content.path) }
@@ -209,7 +209,6 @@ fun ChannelVideoMessageBubble(
                                             currentPositionSeconds = seconds
                                         }
                                     },
-                                    videoPlayerPool = videoPlayerPool,
                                     fileId = if (!hasPath && content.supportsStreaming) content.fileId else 0,
                                     thumbnailData = content.minithumbnail
                                 )

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/ChatAlbumMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/ChatAlbumMessageBubble.kt
@@ -20,17 +20,17 @@ import org.monogram.domain.models.MessageModel
 import org.monogram.domain.models.MessageSendingState
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.components.CompactMediaMosaic
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @Composable
 fun ChatAlbumMessageBubble(
     messages: List<MessageModel>,
     isOutgoing: Boolean,
+    autoplayGifs: Boolean,
+    autoplayVideos: Boolean,
+    modifier: Modifier = Modifier,
     isGroup: Boolean = false,
     isSameSenderAbove: Boolean = false,
     isSameSenderBelow: Boolean = false,
-    autoplayGifs: Boolean,
-    autoplayVideos: Boolean,
     autoDownloadMobile: Boolean = false,
     autoDownloadWifi: Boolean = false,
     autoDownloadRoaming: Boolean = false,
@@ -45,11 +45,9 @@ fun ChatAlbumMessageBubble(
     onReplyClick: (MessageModel) -> Unit = {},
     onReactionClick: (String) -> Unit = {},
     toProfile: (Long) -> Unit = {},
-    modifier: Modifier = Modifier,
     fontSize: Float = 16f,
     letterSpacing: Float = 0f,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     if (messages.isEmpty()) return
@@ -197,7 +195,6 @@ fun ChatAlbumMessageBubble(
                     autoDownloadRoaming = autoDownloadRoaming,
                     toProfile = toProfile,
                     downloadUtils = downloadUtils,
-                    videoPlayerPool = videoPlayerPool,
                     isAnyViewerOpen = isAnyViewerOpen
                 )
 
@@ -266,9 +263,9 @@ fun ChatTimestampInfo(
     time: String,
     isRead: Boolean,
     isOutgoing: Boolean,
-    sendingState: MessageSendingState? = null,
     color: Color,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    sendingState: MessageSendingState? = null
 ) {
     Row(
         modifier = modifier,

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/ContactMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/ContactMessageBubble.kt
@@ -37,10 +37,7 @@ import androidx.compose.ui.unit.sp
 import org.monogram.domain.models.MessageContent
 import org.monogram.domain.models.MessageModel
 import org.monogram.presentation.core.ui.Avatar
-import com.google.i18n.phonenumbers.PhoneNumberUtil
-import org.koin.compose.koinInject
 import org.monogram.presentation.core.util.CountryManager
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -53,7 +50,6 @@ fun ContactMessageBubble(
     fontSize: Float,
     letterSpacing: Float,
     bubbleRadius: Float,
-    videoPlayerPool: VideoPlayerPool,
     isGroup: Boolean = false,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
@@ -136,8 +132,7 @@ fun ContactMessageBubble(
                         Avatar(
                             path = content.avatarPath,
                             name = "${content.firstName} ${content.lastName}".trim(),
-                            size = 56.dp,
-                            videoPlayerPool = videoPlayerPool
+                            size = 56.dp
                         )
                         if (country != null) {
                             Box(

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/GifMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/GifMessageBubble.kt
@@ -1,4 +1,4 @@
-@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
 
 package org.monogram.presentation.features.chats.currentChat.components.chats
 
@@ -36,12 +36,11 @@ import org.monogram.domain.models.MessageContent
 import org.monogram.domain.models.MessageModel
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.AutoDownloadSuppression
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.VideoStickerPlayer
 import org.monogram.presentation.features.chats.currentChat.components.VideoType
 
 @OptIn(UnstableApi::class, ExperimentalMaterial3ExpressiveApi::class)
-@kotlin.OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+@kotlin.OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun GifMessageBubble(
     content: MessageContent.Gif,
@@ -55,6 +54,7 @@ fun GifMessageBubble(
     autoDownloadWifi: Boolean,
     autoDownloadRoaming: Boolean,
     autoplayGifs: Boolean,
+    modifier: Modifier = Modifier,
     onGifClick: (MessageModel) -> Unit = {},
     onCancelDownload: (Int) -> Unit = {},
     onLongClick: (Offset) -> Unit,
@@ -63,9 +63,7 @@ fun GifMessageBubble(
     showMetadata: Boolean = true,
     showReactions: Boolean = true,
     toProfile: (Long) -> Unit = {},
-    modifier: Modifier = Modifier,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val cornerRadius = 18.dp
@@ -197,7 +195,6 @@ fun GifMessageBubble(
                                     modifier = Modifier.fillMaxSize(),
                                     contentScale = ContentScale.Fit,
                                     animate = !isAnyViewerOpen,
-                                    videoPlayerPool = videoPlayerPool,
                                     thumbnailData = content.minithumbnail
                                 )
                             } else {

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/MessageReactionsView.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/MessageReactionsView.kt
@@ -29,7 +29,6 @@ import org.monogram.domain.repository.StickerRepository
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.util.AppPreferences
 import org.monogram.presentation.core.util.coRunCatching
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -39,8 +38,7 @@ fun MessageReactionsView(
     onReactionClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     stickerRepository: StickerRepository = koinInject(),
-    appPreferences: AppPreferences = koinInject(),
-    videoPlayerPool: VideoPlayerPool = koinInject()
+    appPreferences: AppPreferences = koinInject()
 ) {
     val context = LocalContext.current
     val emojiStyle by appPreferences.emojiStyle.collectAsState()
@@ -105,8 +103,7 @@ fun MessageReactionsView(
                             onReactionClick = onReactionClick,
                             emojiFontFamily = emojiFontFamily,
                             stickerRepository = stickerRepository,
-                            customEmojiFileIdsById = customEmojiFileIdsById,
-                            videoPlayerPool = videoPlayerPool
+                            customEmojiFileIdsById = customEmojiFileIdsById
                         )
                     }
                 }
@@ -122,8 +119,7 @@ private fun MessageReactionItem(
     onReactionClick: (String) -> Unit,
     emojiFontFamily: FontFamily,
     stickerRepository: StickerRepository,
-    customEmojiFileIdsById: Map<Long, Long>,
-    videoPlayerPool: VideoPlayerPool
+    customEmojiFileIdsById: Map<Long, Long>
 ) {
     val customEmojiId = reaction.customEmojiId
     val emoji = reaction.emoji
@@ -230,7 +226,6 @@ private fun MessageReactionItem(
                             path = sender.avatar,
                             name = sender.name,
                             size = 22.dp,
-                            videoPlayerPool = videoPlayerPool,
                             modifier = Modifier
                                 .background(backgroundColor, CircleShape)
                                 .padding(1.dp)
@@ -313,8 +308,7 @@ private fun MessageReactionItem(
                             Avatar(
                                 path = sender.avatar,
                                 name = sender.name,
-                                size = 28.dp,
-                                videoPlayerPool = videoPlayerPool
+                                size = 28.dp
                             )
                             Text(
                                 text = sender.name,

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/PollVotersSheet.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/PollVotersSheet.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.sp
 import org.monogram.domain.models.UserModel
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -30,7 +29,6 @@ import org.monogram.presentation.features.chats.currentChat.components.VideoPlay
 fun PollVotersSheet(
     voters: List<UserModel>,
     isLoading: Boolean,
-    videoPlayerPool: VideoPlayerPool,
     onUserClick: (Long) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -88,7 +86,6 @@ fun PollVotersSheet(
                         itemsIndexed(voters) { index, user ->
                             VoterItem(
                                 user = user,
-                                videoPlayerPool = videoPlayerPool,
                                 onClick = { onUserClick(user.id) }
                             )
                             if (index < voters.size - 1) {
@@ -127,7 +124,6 @@ fun PollVotersSheet(
 @Composable
 private fun VoterItem(
     user: UserModel,
-    videoPlayerPool: VideoPlayerPool,
     onClick: () -> Unit
 ) {
     Row(
@@ -141,8 +137,7 @@ private fun VoterItem(
             path = user.avatarPath,
             fallbackPath = user.personalAvatarPath,
             name = user.firstName,
-            size = 40.dp,
-            videoPlayerPool = videoPlayerPool
+            size = 40.dp
         )
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/VideoMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/chats/VideoMessageBubble.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
@@ -41,7 +42,6 @@ import org.monogram.domain.models.MessageContent
 import org.monogram.domain.models.MessageModel
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.AutoDownloadSuppression
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.VideoStickerPlayer
 import org.monogram.presentation.features.chats.currentChat.components.VideoType
 
@@ -60,6 +60,7 @@ fun VideoMessageBubble(
     autoDownloadRoaming: Boolean,
     autoplayVideos: Boolean,
     onVideoClick: (MessageModel) -> Unit,
+    modifier: Modifier = Modifier,
     onCancelDownload: (Int) -> Unit = {},
     onLongClick: (Offset) -> Unit,
     onReplyClick: (MessageModel) -> Unit = {},
@@ -67,9 +68,7 @@ fun VideoMessageBubble(
     showMetadata: Boolean = true,
     showReactions: Boolean = true,
     toProfile: (Long) -> Unit = {},
-    modifier: Modifier = Modifier,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val cornerRadius = 18.dp
@@ -127,8 +126,8 @@ fun VideoMessageBubble(
     var isMuted by remember { mutableStateOf(true) }
     var currentPositionSeconds by remember { mutableIntStateOf(0) }
     var isVisible by remember { mutableStateOf(false) }
-
-    val screenHeightPx = remember { context.resources.displayMetrics.heightPixels }
+    val resources = LocalResources.current
+    val screenHeightPx = remember { resources.displayMetrics.heightPixels }
     val revealedSpoilers = remember { mutableStateListOf<Int>() }
     var isMediaSpoilerRevealed by remember { mutableStateOf(!content.hasSpoiler) }
 
@@ -221,7 +220,6 @@ fun VideoMessageBubble(
                                             currentPositionSeconds = seconds
                                         }
                                     },
-                                    videoPlayerPool = videoPlayerPool,
                                     fileId = if (!hasPath && content.supportsStreaming) content.fileId else 0,
                                     thumbnailData = content.minithumbnail
                                 )

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/inputbar/ChatInputBarComposerSection.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/inputbar/ChatInputBarComposerSection.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import org.monogram.domain.models.*
 import org.monogram.domain.repository.StickerRepository
 import org.monogram.presentation.R
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.chats.BotCommandSuggestions
 import org.monogram.presentation.features.stickers.ui.menu.StickerEmojiMenu
 
@@ -60,7 +59,6 @@ fun ChatInputBarComposerSection(
     isVideoMessageMode: Boolean,
     replyMarkup: ReplyMarkupModel?,
     showSendOptionsSheet: Boolean,
-    videoPlayerPool: VideoPlayerPool,
     stickerRepository: StickerRepository,
     onCancelEdit: () -> Unit,
     onCancelReply: () -> Unit,
@@ -124,8 +122,7 @@ fun ChatInputBarComposerSection(
                     onMentionClick = {
                         onMentionClick(it)
                         onMentionQueryClear()
-                    },
-                    videoPlayerPool = videoPlayerPool
+                    }
                 )
             }
 
@@ -331,7 +328,6 @@ fun ChatInputBarComposerSection(
                     onGifSelected = onGifClick,
                     onSearchFocused = onGifSearchFocusedChange,
                     panelHeight = stickerMenuHeight,
-                    videoPlayerPool = videoPlayerPool,
                     stickerRepository = stickerRepository
                 )
             }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/inputbar/FullScreenEditorSheet.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/inputbar/FullScreenEditorSheet.kt
@@ -47,7 +47,6 @@ import org.monogram.domain.repository.*
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.ItemPosition
 import org.monogram.presentation.features.chats.chatList.components.SettingsTextField
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.profile.logs.components.calculateDiff
 import org.monogram.presentation.features.stickers.ui.menu.StickerEmojiMenu
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
@@ -138,7 +137,6 @@ fun FullScreenEditorSheet(
     isOverMessageLimit: Boolean,
     currentMessageLength: Int,
     maxMessageLength: Int,
-    videoPlayerPool: VideoPlayerPool,
     stickerRepository: StickerRepository,
     isPremiumUser: Boolean,
     isSecretChat: Boolean,
@@ -609,7 +607,6 @@ fun FullScreenEditorSheet(
                 onGifSelected = {},
                 emojiOnlyMode = true,
                 onSearchFocused = {},
-                videoPlayerPool = videoPlayerPool,
                 stickerRepository = stickerRepository
             )
         }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/inputbar/MentionSuggestions.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/inputbar/MentionSuggestions.kt
@@ -18,12 +18,10 @@ import org.monogram.domain.models.UserModel
 import org.monogram.domain.models.UserStatusType
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.util.getUserStatusText
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @Composable
 fun MentionSuggestions(
     suggestions: List<UserModel>,
-    videoPlayerPool: VideoPlayerPool,
     onMentionClick: (UserModel) -> Unit
 ) {
     val context = LocalContext.current
@@ -49,8 +47,7 @@ fun MentionSuggestions(
                         fallbackPath = user.personalAvatarPath,
                         name = user.firstName,
                         size = 36.dp,
-                        isOnline = user.userStatus == UserStatusType.ONLINE,
-                        videoPlayerPool = videoPlayerPool
+                        isOnline = user.userStatus == UserStatusType.ONLINE
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                     Column(modifier = Modifier.weight(1f)) {

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/pins/PinnedMessagesListSheet.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/components/pins/PinnedMessagesListSheet.kt
@@ -34,7 +34,6 @@ fun PinnedMessagesListSheet(
     onReplyClick: (MessageModel) -> Unit,
     onReactionClick: (Long, String) -> Unit,
     downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool,
     isAnyViewerOpen: Boolean = false
 ) {
     val messages = state.allPinnedMessages
@@ -129,8 +128,7 @@ fun PinnedMessagesListSheet(
                                     letterSpacing = state.letterSpacing,
                                     bubbleRadius = state.bubbleRadius,
                                     stickerSize = state.stickerSize,
-                                    downloadUtils = downloadUtils,
-                                    videoPlayerPool = videoPlayerPool
+                                    downloadUtils = downloadUtils
                                 )
                             } else if (item is GroupedMessageItem.Album) {
                                 AlbumMessageBubbleContainer(
@@ -147,8 +145,7 @@ fun PinnedMessagesListSheet(
                                     onGoToReply = { onReplyClick(it) },
                                     onReactionClick = onReactionClick,
                                     toProfile = {},
-                                    downloadUtils = downloadUtils,
-                                    videoPlayerPool = videoPlayerPool
+                                    downloadUtils = downloadUtils
                                 )
                             }
                         } else {
@@ -175,8 +172,7 @@ fun PinnedMessagesListSheet(
                                     onGoToReply = { onReplyClick(it) },
                                     onReactionClick = onReactionClick,
                                     toProfile = {},
-                                    downloadUtils = downloadUtils,
-                                    videoPlayerPool = videoPlayerPool
+                                    downloadUtils = downloadUtils
                                 )
                             } else if (item is GroupedMessageItem.Album) {
                                 AlbumMessageBubbleContainer(
@@ -193,8 +189,7 @@ fun PinnedMessagesListSheet(
                                     onGoToReply = { onReplyClick(it) },
                                     onReactionClick = onReactionClick,
                                     toProfile = {},
-                                    downloadUtils = downloadUtils,
-                                    videoPlayerPool = videoPlayerPool
+                                    downloadUtils = downloadUtils
                                 )
                             }
                         }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/newChat/DefaultNewChatComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/newChat/DefaultNewChatComponent.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.launch
 import org.monogram.domain.repository.ChatsListRepository
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultNewChatComponent(
@@ -23,7 +22,6 @@ class DefaultNewChatComponent(
 
     private val userRepository: UserRepository = container.repositories.userRepository
     private val chatsListRepository: ChatsListRepository = container.repositories.chatsListRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val scope = componentScope
     private val _state = MutableStateFlow(NewChatComponent.State())

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/newChat/NewChatComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/newChat/NewChatComponent.kt
@@ -2,11 +2,9 @@ package org.monogram.presentation.features.chats.newChat
 
 import kotlinx.coroutines.flow.StateFlow
 import org.monogram.domain.models.UserModel
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface NewChatComponent {
     val state: StateFlow<State>
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBack()
     fun onUserClicked(userId: Long)

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/newChat/NewChatContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/newChat/NewChatContent.kt
@@ -50,7 +50,6 @@ import org.monogram.presentation.features.chats.chatList.components.NewChannelCo
 import org.monogram.presentation.features.chats.chatList.components.NewGroupContent
 import org.monogram.presentation.features.chats.chatList.components.SectionHeader
 import org.monogram.presentation.features.chats.chatList.components.SettingsTextField
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -251,7 +250,6 @@ fun NewChatContent(component: NewChatComponent) {
                                 "channel" -> component.onCreateChannel()
                             }
                         },
-                        videoPlayerPool = component.videoPlayerPool,
                         onUserClick = { user ->
                             if (state.step == NewChatComponent.Step.GROUP_MEMBERS) {
                                 component.onToggleUserSelection(user.id)
@@ -286,8 +284,7 @@ fun NewChatContent(component: NewChatComponent) {
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
                             )
                         },
-                        onAutoDeleteTimeChange = component::onAutoDeleteTimeChange,
-                        videoPlayerPool = component.videoPlayerPool
+                        onAutoDeleteTimeChange = component::onAutoDeleteTimeChange
                     )
                 }
 
@@ -304,8 +301,7 @@ fun NewChatContent(component: NewChatComponent) {
                                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
                             )
                         },
-                        onAutoDeleteTimeChange = component::onAutoDeleteTimeChange,
-                        videoPlayerPool = component.videoPlayerPool
+                        onAutoDeleteTimeChange = component::onAutoDeleteTimeChange
                     )
                 }
             }
@@ -410,7 +406,6 @@ fun NewChatContent(component: NewChatComponent) {
 private fun ContactsList(
     state: NewChatComponent.State,
     isSearchActive: Boolean,
-    videoPlayerPool: VideoPlayerPool,
     onActionClick: (String) -> Unit,
     onUserClick: (UserModel) -> Unit,
     onOpenProfile: (UserModel) -> Unit,
@@ -525,8 +520,7 @@ private fun ContactsList(
                 onClick = { onUserClick(user) },
                 onOpenProfile = { onOpenProfile(user) },
                 onEditContact = { onEditContact(user) },
-                onRemoveContact = { onRemoveContact(user) },
-                videoPlayerPool = videoPlayerPool
+                onRemoveContact = { onRemoveContact(user) }
             )
         }
 
@@ -621,7 +615,6 @@ private fun ContactItem(
     showCheckbox: Boolean,
     enableLongPress: Boolean,
     position: ItemPosition,
-    videoPlayerPool: VideoPlayerPool,
     onClick: () -> Unit,
     onOpenProfile: () -> Unit,
     onEditContact: () -> Unit,
@@ -675,8 +668,7 @@ private fun ContactItem(
                     fallbackPath = user.personalAvatarPath,
                     name = user.firstName,
                     size = 40.dp,
-                    isOnline = user.userStatus == UserStatusType.ONLINE && !isSupport,
-                    videoPlayerPool = videoPlayerPool
+                    isOnline = user.userStatus == UserStatusType.ONLINE && !isSupport
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 Column(modifier = Modifier.weight(1f)) {

--- a/presentation/src/main/java/org/monogram/presentation/features/instantview/InstantViewer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/instantview/InstantViewer.kt
@@ -1,4 +1,4 @@
-@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
 
 package org.monogram.presentation.features.instantview
 
@@ -44,7 +44,6 @@ import org.monogram.domain.models.webapp.PageBlock
 import org.monogram.domain.models.webapp.RichText
 import org.monogram.domain.repository.MessageRepository
 import org.monogram.presentation.R
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.chats.normalizeUrl
 import org.monogram.presentation.features.instantview.components.*
 import org.monogram.presentation.features.stickers.ui.menu.MenuOptionRow
@@ -56,7 +55,6 @@ import java.util.*
 @Composable
 fun InstantViewer(
     url: String,
-    videoPlayerPool: VideoPlayerPool,
     messageRepository: MessageRepository,
     onDismiss: () -> Unit,
     onOpenWebView: (String) -> Unit
@@ -66,7 +64,7 @@ fun InstantViewer(
 
     var instantView by remember(currentUrl) { mutableStateOf<InstantViewModel?>(null) }
     var isLoading by remember { mutableStateOf(true) }
-    var textSizeMultiplier by remember { mutableStateOf(1f) }
+    var textSizeMultiplier by remember { mutableFloatStateOf(1f) }
     var isSearching by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
     var showSettingsMenu by remember { mutableStateOf(false) }
@@ -249,7 +247,7 @@ fun InstantViewer(
                                 verticalArrangement = Arrangement.spacedBy(20.dp)
                             ) {
                                 items(blocks) { block ->
-                                    InstantViewBlock(block, textSizeMultiplier, videoPlayerPool)
+                                    InstantViewBlock(block, textSizeMultiplier)
                                 }
                                 item {
                                     Spacer(modifier = Modifier.height(48.dp))
@@ -357,7 +355,7 @@ fun InstantViewer(
 }
 
 @Composable
-fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPool: VideoPlayerPool) {
+fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float) {
     val onUrlClick = LocalOnUrlClick.current
     LocalUriHandler.current
     when (block) {
@@ -503,8 +501,7 @@ fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPoo
                             fileId = block.video.fileId,
                             modifier = Modifier.fillMaxSize(),
                             shouldLoop = block.isLooped,
-                            contentScale = ContentScale.FillWidth,
-                            videoPlayerPool = videoPlayerPool
+                            contentScale = ContentScale.FillWidth
                         )
                     } else {
                         Icon(
@@ -540,8 +537,7 @@ fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPoo
                             fileId = block.animation.fileId,
                             modifier = Modifier.fillMaxSize(),
                             shouldLoop = true,
-                            contentScale = ContentScale.FillWidth,
-                            videoPlayerPool = videoPlayerPool
+                            contentScale = ContentScale.FillWidth
                         )
                     } else {
                         Icon(
@@ -676,7 +672,7 @@ fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPoo
                     }
                     Spacer(modifier = Modifier.height(12.dp))
                     block.pageBlocks.forEach { innerBlock ->
-                        InstantViewBlock(innerBlock, textSizeMultiplier, videoPlayerPool)
+                        InstantViewBlock(innerBlock, textSizeMultiplier)
                     }
                     PageBlockCaptionView(block.caption, textSizeMultiplier, modifier = Modifier.padding(top = 12.dp))
                 }
@@ -755,14 +751,14 @@ fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPoo
                     )
                     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         item.pageBlocks.forEach { innerBlock ->
-                            InstantViewBlock(innerBlock, textSizeMultiplier, videoPlayerPool)
+                            InstantViewBlock(innerBlock, textSizeMultiplier)
                         }
                     }
                 }
             }
         }
 
-        is PageBlock.Cover -> InstantViewBlock(block.cover, textSizeMultiplier, videoPlayerPool)
+        is PageBlock.Cover -> InstantViewBlock(block.cover, textSizeMultiplier)
         is PageBlock.Details -> {
             var isOpen by remember { mutableStateOf(block.isOpen) }
             Surface(
@@ -801,7 +797,7 @@ fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPoo
                             verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             block.pageBlocks.forEach { innerBlock ->
-                                InstantViewBlock(innerBlock, textSizeMultiplier, videoPlayerPool)
+                                InstantViewBlock(innerBlock, textSizeMultiplier)
                             }
                         }
                     }
@@ -812,7 +808,7 @@ fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPoo
         is PageBlock.Collage -> {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 block.pageBlocks.forEach { innerBlock ->
-                    InstantViewBlock(innerBlock, textSizeMultiplier, videoPlayerPool)
+                    InstantViewBlock(innerBlock, textSizeMultiplier)
                 }
                 PageBlockCaptionView(block.caption, textSizeMultiplier)
             }
@@ -821,7 +817,7 @@ fun InstantViewBlock(block: PageBlock, textSizeMultiplier: Float, videoPlayerPoo
         is PageBlock.Slideshow -> {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 block.pageBlocks.forEach { innerBlock ->
-                    InstantViewBlock(innerBlock, textSizeMultiplier, videoPlayerPool)
+                    InstantViewBlock(innerBlock, textSizeMultiplier)
                 }
                 PageBlockCaptionView(block.caption, textSizeMultiplier)
             }

--- a/presentation/src/main/java/org/monogram/presentation/features/instantview/components/InstantViewComponents.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/instantview/components/InstantViewComponents.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import org.monogram.domain.models.webapp.PageBlockCaption
 import org.monogram.domain.models.webapp.RichText
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.VideoStickerPlayer
 import org.monogram.presentation.features.chats.currentChat.components.VideoType
 import org.monogram.presentation.features.chats.currentChat.components.chats.normalizeUrl
@@ -79,13 +78,13 @@ fun RichTextView(
 fun AsyncImageWithDownload(
     path: String?,
     fileId: Int,
-    minithumbnail: ByteArray? = null,
     modifier: Modifier = Modifier,
+    minithumbnail: ByteArray? = null,
     contentScale: ContentScale = ContentScale.Fit
 ) {
     val messageRepository = LocalMessageRepository.current
     var currentPath by remember(fileId) { mutableStateOf(path) }
-    var progress by remember { mutableStateOf(0f) }
+    var progress by remember { mutableFloatStateOf(0f) }
 
     LaunchedEffect(path, fileId) {
         if (!path.isNullOrEmpty()) {
@@ -159,7 +158,6 @@ fun AsyncImageWithDownload(
 @Composable
 fun AsyncVideoWithDownload(
     path: String?,
-    videoPlayerPool: VideoPlayerPool,
     fileId: Int,
     modifier: Modifier = Modifier,
     shouldLoop: Boolean = true,
@@ -167,7 +165,7 @@ fun AsyncVideoWithDownload(
 ) {
     val messageRepository = LocalMessageRepository.current
     var currentPath by remember(fileId) { mutableStateOf(path) }
-    var progress by remember { mutableStateOf(0f) }
+    var progress by remember { mutableFloatStateOf(0f) }
 
     LaunchedEffect(path, fileId) {
         if (!path.isNullOrEmpty()) {
@@ -201,8 +199,7 @@ fun AsyncVideoWithDownload(
             modifier = modifier,
             animate = true,
             shouldLoop = shouldLoop,
-            contentScale = contentScale,
-            videoPlayerPool = videoPlayerPool
+            contentScale = contentScale
         )
     } else {
         Box(

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/DefaultProfileComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/DefaultProfileComponent.kt
@@ -12,7 +12,6 @@ import org.monogram.domain.repository.*
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.core.util.coRunCatching
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultProfileComponent(
@@ -33,7 +32,6 @@ class DefaultProfileComponent(
     private val userRepository: UserRepository = container.repositories.userRepository
     private val privacyRepository: PrivacyRepository = container.repositories.privacyRepository
     override val messageRepository: MessageRepository = container.repositories.messageRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
     private val locationRepository: LocationRepository = container.repositories.locationRepository
     private val botPreferences: BotPreferencesProvider = container.preferences.botPreferencesProvider
     override val downloadUtils: IDownloadUtils = container.utils.downloadUtils()

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/ProfileComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/ProfileComponent.kt
@@ -5,13 +5,11 @@ import org.monogram.domain.models.*
 import org.monogram.domain.repository.ChatMemberStatus
 import org.monogram.domain.repository.MessageRepository
 import org.monogram.presentation.core.util.IDownloadUtils
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface ProfileComponent {
     val state: Value<State>
     val messageRepository: MessageRepository
     val downloadUtils: IDownloadUtils
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBack()
     fun onTabSelected(index: Int)

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/ProfileContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/ProfileContent.kt
@@ -325,8 +325,7 @@ fun ProfileContent(component: ProfileComponent) {
                                 onAvatarClick = component::onAvatarClick,
                                 userModel = user,
                                 chatModel = chat,
-                                onActionClick = {},
-                                videoPlayerPool = component.videoPlayerPool
+                                onActionClick = {}
                             )
                         }
                     }
@@ -365,8 +364,7 @@ fun ProfileContent(component: ProfileComponent) {
                                     onShowPermissions = component::onShowPermissions,
                                     onAcceptTOS = component::onAcceptTOS,
                                     onToggleContact = component::onToggleContact,
-                                    onLocationClick = component::onLocationClick,
-                                    videoPlayerPool = component.videoPlayerPool
+                                    onLocationClick = component::onLocationClick
                                 )
                             }
                             Spacer(modifier = Modifier.height(12.dp))
@@ -385,8 +383,7 @@ fun ProfileContent(component: ProfileComponent) {
                         onMemberLongClick = component::onMemberLongClick,
                         onLoadMedia = { msg ->
                             component.onDownloadMedia(msg)
-                        },
-                        videoPlayerPool = component.videoPlayerPool
+                        }
                     )
 
                     item(span = { GridItemSpan(3) }) {

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/AdminManageComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/AdminManageComponent.kt
@@ -3,11 +3,9 @@ package org.monogram.presentation.features.profile.admin
 import com.arkivanov.decompose.value.Value
 import org.monogram.domain.models.GroupMemberModel
 import org.monogram.domain.repository.ChatMemberStatus
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface AdminManageComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBack()
     fun onSave()

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/AdminManageContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/AdminManageContent.kt
@@ -100,8 +100,7 @@ fun AdminManageContent(component: AdminManageComponent) {
                                     path = user.avatarPath,
                                     fallbackPath = user.personalAvatarPath,
                                     name = user.firstName,
-                                    size = 64.dp,
-                                    videoPlayerPool = component.videoPlayerPool
+                                    size = 64.dp
                                 )
                                 Spacer(Modifier.width(16.dp))
                                 Column(modifier = Modifier.weight(1f)) {

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/ChatEditComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/ChatEditComponent.kt
@@ -2,11 +2,9 @@ package org.monogram.presentation.features.profile.admin
 
 import com.arkivanov.decompose.value.Value
 import org.monogram.domain.models.ChatModel
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface ChatEditComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBack()
     fun onUpdateTitle(title: String)

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/ChatEditContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/ChatEditContent.kt
@@ -112,7 +112,7 @@ fun ChatEditContent(component: ChatEditComponent) {
                             },
                         contentAlignment = Alignment.Center
                     ) {
-                        Avatar(path = state.avatarPath, name = state.title, size = 100.dp, videoPlayerPool = component.videoPlayerPool)
+                        Avatar(path = state.avatarPath, name = state.title, size = 100.dp)
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/DefaultAdminManageComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/DefaultAdminManageComponent.kt
@@ -8,7 +8,6 @@ import org.monogram.domain.repository.ChatMemberStatus
 import org.monogram.domain.repository.ChatsListRepository
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultAdminManageComponent(
@@ -20,7 +19,6 @@ class DefaultAdminManageComponent(
 
     private val userRepository: UserRepository = container.repositories.userRepository
     private val chatsListRepository: ChatsListRepository = container.repositories.chatsListRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val scope = componentScope
     private val _state = MutableValue(AdminManageComponent.State(chatId = chatId, userId = userId))

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/DefaultChatEditComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/DefaultChatEditComponent.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.launch
 import org.monogram.domain.repository.ChatsListRepository
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultChatEditComponent(
@@ -22,7 +21,6 @@ class DefaultChatEditComponent(
 
     private val chatsListRepository: ChatsListRepository = container.repositories.chatsListRepository
     private val userRepository: UserRepository = container.repositories.userRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val scope = componentScope
     private val _state = MutableValue(ChatEditComponent.State(chatId = chatId))

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/DefaultMemberListComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/DefaultMemberListComponent.kt
@@ -11,7 +11,6 @@ import org.monogram.domain.repository.ChatMemberStatus
 import org.monogram.domain.repository.ChatMembersFilter
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultMemberListComponent(
@@ -24,7 +23,6 @@ class DefaultMemberListComponent(
 ) : MemberListComponent, AppComponentContext by context {
 
     private val userRepository: UserRepository = container.repositories.userRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val scope = componentScope
     private val _state = MutableValue(MemberListComponent.State(chatId = chatId, type = type))

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/MemberListComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/MemberListComponent.kt
@@ -2,11 +2,9 @@ package org.monogram.presentation.features.profile.admin
 
 import com.arkivanov.decompose.value.Value
 import org.monogram.domain.models.GroupMemberModel
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface MemberListComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBack()
     fun onMemberClick(member: GroupMemberModel)

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/admin/MemberListContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/admin/MemberListContent.kt
@@ -177,8 +177,7 @@ fun MemberListContent(component: MemberListComponent) {
                                     path = member.user.avatarPath,
                                     fallbackPath = member.user.personalAvatarPath,
                                     name = member.user.firstName,
-                                    size = 48.dp,
-                                    videoPlayerPool = component.videoPlayerPool
+                                    size = 48.dp
                                 )
                             },
                             trailingContent = {

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/components/LinkedChatItem.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/components/LinkedChatItem.kt
@@ -17,13 +17,11 @@ import androidx.compose.ui.unit.dp
 import org.monogram.domain.models.ChatModel
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @Composable
 fun LinkedChatItem(
     chat: ChatModel,
     isDiscussion: Boolean,
-    videoPlayerPool: VideoPlayerPool,
     onClick: () -> Unit
 ) {
     Surface(
@@ -45,8 +43,7 @@ fun LinkedChatItem(
                 fallbackPath = chat.personalAvatarPath,
                 name = chat.title,
                 size = 64.dp,
-                modifier = Modifier.clip(CircleShape),
-                videoPlayerPool = videoPlayerPool
+                modifier = Modifier.clip(CircleShape)
             )
 
             Spacer(modifier = Modifier.width(12.dp))

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileHeader.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileHeader.kt
@@ -23,14 +23,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
 
 
 @Composable
 fun ProfileHeader(
     avatarPath: String?,
-    videoPlayerPool: VideoPlayerPool,
     profilePhotos: List<String>,
     title: String,
     subtitle: String,
@@ -57,7 +55,6 @@ fun ProfileHeader(
                 name = title,
                 size = 120.dp,
                 fontSize = 48,
-                videoPlayerPool = videoPlayerPool,
                 modifier = Modifier
                     .clip(CircleShape)
                     .clickable(enabled = displayPath != null) { onAvatarClick() }

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileHeaderTransformed.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileHeaderTransformed.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.unit.sp
 import org.monogram.domain.models.ChatModel
 import org.monogram.domain.models.UserModel
 import org.monogram.presentation.core.ui.AvatarHeader
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
 
 @Composable
@@ -50,8 +49,7 @@ fun ProfileHeaderTransformed(
     progress: Float,
     contentPadding: PaddingValues,
     onAvatarClick: () -> Unit,
-    onActionClick: () -> Unit,
-    videoPlayerPool: VideoPlayerPool
+    onActionClick: () -> Unit
 ) {
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
 
@@ -82,8 +80,7 @@ fun ProfileHeaderTransformed(
                     path = avatarPath,
                     name = title,
                     size = avatarSize.coerceAtMost(headerHeight),
-                    avatarCornerPercent = avatarCornerPercent,
-                    videoPlayerPool = videoPlayerPool
+                    avatarCornerPercent = avatarCornerPercent
                 )
             }
 

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileMediaSection.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileMediaSection.kt
@@ -43,7 +43,6 @@ import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.ui.rememberShimmerBrush
 import org.monogram.presentation.core.util.getUserStatusText
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.VideoStickerPlayer
 import org.monogram.presentation.features.chats.currentChat.components.VideoType
 import org.monogram.presentation.features.profile.ProfileComponent
@@ -57,7 +56,6 @@ fun LazyGridScope.profileMediaSection(
     state: ProfileComponent.State,
     isGroup: Boolean,
     tabs: MutableList<@Composable (() -> String)>,
-    videoPlayerPool: VideoPlayerPool,
     onTabSelected: (Int) -> Unit,
     onMessageClick: (MessageModel) -> Unit,
     onMessageLongClick: (MessageModel) -> Unit,
@@ -163,12 +161,12 @@ fun LazyGridScope.profileMediaSection(
     if (isGroup) {
         when (state.selectedTabIndex) {
             0 -> mediaGrid(state.mediaMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick, onLoadMedia)
-            1 -> membersList(state.members, videoPlayerPool, state.isLoadingMembers, state.canLoadMoreMembers, onLoadMore, onMemberClick, onMemberLongClick)
+            1 -> membersList(state.members, state.isLoadingMembers, state.canLoadMoreMembers, onLoadMore, onMemberClick, onMemberLongClick)
             2 -> filesList(state.fileMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
             3 -> audioList(state.audioMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
             4 -> voiceList(state.voiceMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
             5 -> linksList(state.linkMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
-            6 -> gifsGrid(state.gifMessages, videoPlayerPool, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
+            6 -> gifsGrid(state.gifMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
         }
     } else {
         when (state.selectedTabIndex) {
@@ -177,7 +175,7 @@ fun LazyGridScope.profileMediaSection(
             2 -> audioList(state.audioMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
             3 -> voiceList(state.voiceMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
             4 -> linksList(state.linkMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
-            5 -> gifsGrid(state.gifMessages, videoPlayerPool, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
+            5 -> gifsGrid(state.gifMessages, state.isLoadingMedia, state.canLoadMoreMedia, onLoadMore, onMessageClick)
         }
     }
 
@@ -275,7 +273,6 @@ private fun ScrollableRow(
 
 private fun LazyGridScope.membersList(
     members: List<GroupMemberModel>,
-    videoPlayerPool: VideoPlayerPool,
     isLoading: Boolean,
     canLoadMore: Boolean,
     onLoadMore: () -> Unit,
@@ -401,7 +398,6 @@ private fun LazyGridScope.membersList(
                         name = user.firstName,
                         isOnline = user.userStatus == UserStatusType.ONLINE,
                         size = 40.dp,
-                        videoPlayerPool = videoPlayerPool,
                         modifier = Modifier.combinedClickable(
                             onClick = { onMemberClick(user.id) },
                             onLongClick = { onMemberLongClick(user.id) }
@@ -826,7 +822,6 @@ private fun LazyGridScope.linksList(
 
 private fun LazyGridScope.gifsGrid(
     messages: List<MessageModel>,
-    videoPlayerPool: VideoPlayerPool,
     isLoading: Boolean,
     canLoadMore: Boolean,
     onLoadMore: () -> Unit,
@@ -868,8 +863,7 @@ private fun LazyGridScope.gifsGrid(
                         path = content.path!!,
                         type = VideoType.Gif,
                         modifier = Modifier.fillMaxSize(),
-                        animate = true,
-                        videoPlayerPool = videoPlayerPool
+                        animate = true
                     )
                     Box(
                         modifier = Modifier

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileSections.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/components/ProfileSections.kt
@@ -101,11 +101,8 @@ import androidx.core.net.toUri
 import org.monogram.domain.models.UserTypeEnum
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.*
-import com.google.i18n.phonenumbers.PhoneNumberUtil
-import org.koin.compose.koinInject
 import org.monogram.presentation.core.util.CountryManager
 import org.monogram.presentation.core.util.OperatorManager
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.profile.ProfileComponent
 import java.util.Calendar
 
@@ -326,7 +323,6 @@ private fun SectionHeaderSkeleton(shimmer: androidx.compose.ui.graphics.Brush) {
 @Composable
 fun ProfileInfoSection(
     state: ProfileComponent.State,
-    videoPlayerPool: VideoPlayerPool,
     localClipboard: Clipboard,
     onOpenMiniApp: (String, String, Long) -> Unit = { _, _, _ -> },
     onSendMessage: () -> Unit = {},
@@ -439,8 +435,7 @@ fun ProfileInfoSection(
         LinkedChatItem(
             chat = linkedChat,
             isDiscussion = chat?.isChannel == true,
-            onClick = onLinkedChatClick,
-            videoPlayerPool = videoPlayerPool
+            onClick = onLinkedChatClick
         )
     }
 

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/logs/DefaultProfileLogsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/logs/DefaultProfileLogsComponent.kt
@@ -11,7 +11,6 @@ import org.monogram.domain.repository.MessageRepository
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultProfileLogsComponent(
@@ -24,7 +23,6 @@ class DefaultProfileLogsComponent(
 
     override val messageRepository: MessageRepository = container.repositories.messageRepository
     private val userRepository: UserRepository = container.repositories.userRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val scope = componentScope
     private val _state = MutableValue(ProfileLogsComponent.State())

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/logs/ProfileLogsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/logs/ProfileLogsComponent.kt
@@ -5,13 +5,11 @@ import org.monogram.domain.models.ChatEventLogFiltersModel
 import org.monogram.domain.models.ChatEventModel
 import org.monogram.domain.repository.MessageRepository
 import org.monogram.presentation.core.util.IDownloadUtils
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface ProfileLogsComponent {
     val state: Value<State>
     val messageRepository: MessageRepository
     val downloadUtils: IDownloadUtils
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBack()
     fun onLoadMore()

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/logs/ProfileLogsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/logs/ProfileLogsContent.kt
@@ -376,7 +376,7 @@ fun ProfileLogsContent(component: ProfileLogsComponent) {
                                         .padding(horizontal = 12.dp, vertical = 8.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Avatar(path = info.avatarPath, videoPlayerPool = component.videoPlayerPool, name = info.name, size = 36.dp)
+                                    Avatar(path = info.avatarPath, name = info.name, size = 36.dp)
                                     Spacer(Modifier.width(12.dp))
                                     Text(
                                         text = info.name,

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/logs/components/ActionDetails.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/logs/components/ActionDetails.kt
@@ -279,8 +279,7 @@ private fun TargetUserRow(
             path = info?.avatarPath,
             name = name,
             size = 28.dp,
-            fontSize = 12,
-            videoPlayerPool = component.videoPlayerPool
+            fontSize = 12
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/logs/components/LogBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/logs/components/LogBubble.kt
@@ -104,7 +104,6 @@ fun LogBubble(
             name = senderName,
             size = 40.dp,
             fontSize = 16,
-            videoPlayerPool = component.videoPlayerPool,
             onClick = {
                 if (event.memberId is MessageSenderModel.User) {
                     component.onUserClick((event.memberId as MessageSenderModel.User).userId)

--- a/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/GifsGrid.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/GifsGrid.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.delay
 import org.monogram.domain.models.GifModel
 import org.monogram.domain.repository.StickerRepository
 import org.monogram.presentation.R
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.VideoStickerPlayer
 import org.monogram.presentation.features.chats.currentChat.components.VideoType
 import org.monogram.presentation.features.stickers.ui.view.shimmerEffect
@@ -46,7 +45,6 @@ fun GifsView(
     onGifSelected: (GifModel) -> Unit,
     onSearchFocused: (Boolean) -> Unit,
     contentPadding: PaddingValues = PaddingValues(0.dp),
-    videoPlayerPool: VideoPlayerPool,
     stickerRepository: StickerRepository
 ) {
     var searchQuery by remember { mutableStateOf("") }
@@ -171,7 +169,6 @@ fun GifsView(
                             gif = gif,
                             stickerRepository = stickerRepository,
                             onGifSelected = onGifClick,
-                            videoPlayerPool = videoPlayerPool,
                             animate = index in visibleRange
                         )
                     }
@@ -288,7 +285,6 @@ fun GifSearchBar(
 @UnstableApi
 @Composable
 fun GifItem(
-    videoPlayerPool: VideoPlayerPool,
     gif: GifModel,
     stickerRepository: StickerRepository,
     onGifSelected: (GifModel) -> Unit,
@@ -342,7 +338,6 @@ fun GifItem(
                         type = VideoType.Gif,
                         modifier = Modifier.fillMaxSize(),
                         contentScale = ContentScale.Crop,
-                        videoPlayerPool = videoPlayerPool,
                         animate = animate,
                         thumbnailData = thumbPath
                     )

--- a/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/MessageOptionsMenu.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/MessageOptionsMenu.kt
@@ -50,7 +50,6 @@ import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.util.AppPreferences
 import org.monogram.presentation.features.chats.currentChat.chatContent.DeleteMessagesSheet
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.features.chats.currentChat.components.chats.getEmojiFontFamily
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
 import java.text.SimpleDateFormat
@@ -83,7 +82,6 @@ fun MessageOptionsMenu(
     isLoadingViewers: Boolean = false,
     onReloadViewers: () -> Unit = {},
     onViewerClick: (Long) -> Unit = {},
-    videoPlayerPool: VideoPlayerPool,
     bubbleRadius: Float = 18f,
     splitOffset: Int? = null,
     onReply: () -> Unit,
@@ -791,7 +789,6 @@ fun MessageOptionsMenu(
                                         ViewerRow(
                                             viewer = viewer,
                                             dateFormat = viewerDateFormat,
-                                            videoPlayerPool = videoPlayerPool,
                                             onClick = {
                                                 animateOutAndDismiss {
                                                     onViewerClick(viewer.user.id)
@@ -1063,7 +1060,6 @@ private fun ReactionsRow(
 private fun ViewerRow(
     viewer: MessageViewerModel,
     dateFormat: SimpleDateFormat,
-    videoPlayerPool: VideoPlayerPool,
     onClick: () -> Unit
 ) {
     val fullName = remember(viewer.user.firstName, viewer.user.lastName) {
@@ -1090,7 +1086,6 @@ private fun ViewerRow(
             fallbackPath = viewer.user.personalAvatarPath,
             name = fullName,
             size = 32.dp,
-            videoPlayerPool = videoPlayerPool,
             fontSize = 12,
             onClick = onClick
         )

--- a/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/StickerEmojiMenu.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/StickerEmojiMenu.kt
@@ -22,7 +22,6 @@ import org.monogram.domain.models.GifModel
 import org.monogram.domain.models.StickerModel
 import org.monogram.domain.repository.StickerRepository
 import org.monogram.presentation.R
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,7 +32,6 @@ fun StickerEmojiMenu(
     panelHeight: Dp = 400.dp,
     emojiOnlyMode: Boolean = false,
     onSearchFocused: (Boolean) -> Unit = {},
-    videoPlayerPool: VideoPlayerPool,
     stickerRepository: StickerRepository
 ) {
     var selectedTab by remember(emojiOnlyMode) { mutableIntStateOf(if (emojiOnlyMode) 1 else 0) }
@@ -91,7 +89,6 @@ fun StickerEmojiMenu(
                             onSearchFocused(focused)
                         },
                         contentPadding = PaddingValues(bottom = 76.dp),
-                        videoPlayerPool = videoPlayerPool,
                         stickerRepository = stickerRepository
                     )
                 }

--- a/presentation/src/main/java/org/monogram/presentation/settings/adblock/AdBlockComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/adblock/AdBlockComponent.kt
@@ -14,12 +14,10 @@ import org.monogram.domain.models.ChatModel
 import org.monogram.domain.repository.ChatsListRepository
 import org.monogram.presentation.core.util.AppPreferences
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 interface AdBlockComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
     fun onBackClicked()
     fun onAdBlockEnabledChanged(enabled: Boolean)
     fun onAddKeywords(keywords: String)
@@ -53,7 +51,6 @@ class DefaultAdBlockComponent(
     private val chatsRepository: ChatsListRepository = container.repositories.chatsListRepository
     private val clipManager: ClipManager = container.utils.clipManager
     private val assetsManager: AssetsManager = container.utils.assetsManager()
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state = MutableValue(
         AdBlockComponent.State(

--- a/presentation/src/main/java/org/monogram/presentation/settings/adblock/AdBlockContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/adblock/AdBlockContent.kt
@@ -29,7 +29,6 @@ import org.monogram.domain.models.ChatModel
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.features.chats.chatList.components.SettingsTextField
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.core.ui.ItemPosition
 import org.monogram.presentation.core.ui.SettingsSwitchTile
 import org.monogram.presentation.core.ui.SettingsTile
@@ -178,8 +177,7 @@ fun AdBlockContent(component: AdBlockComponent) {
             channels = state.whitelistedChannelModels,
             onDismiss = component::onDismissBottomSheet,
             onRemove = component::onRemoveWhitelistedChannel,
-            onClear = component::onClearWhitelistedChannels,
-            videoPlayerPool = component.videoPlayerPool
+            onClear = component::onClearWhitelistedChannels
         )
     }
 }
@@ -327,7 +325,6 @@ private fun AddKeywordBottomSheet(
 @Composable
 private fun WhitelistedChannelsBottomSheet(
     channels: List<ChatModel>,
-    videoPlayerPool: VideoPlayerPool,
     onDismiss: () -> Unit,
     onRemove: (Long) -> Unit,
     onClear: () -> Unit
@@ -430,7 +427,6 @@ private fun WhitelistedChannelsBottomSheet(
                                     path = channel.avatarPath,
                                     fallbackPath = channel.personalAvatarPath,
                                     name = channel.title,
-                                    videoPlayerPool = videoPlayerPool,
                                     size = 48.dp
                                 )
                             },

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
@@ -17,7 +17,6 @@ import org.monogram.domain.models.WallpaperModel
 import org.monogram.domain.repository.SettingsRepository
 import org.monogram.domain.repository.StickerRepository
 import org.monogram.presentation.core.util.*
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 import org.json.JSONObject
 import java.io.File
@@ -26,7 +25,6 @@ import java.net.URL
 interface ChatSettingsComponent {
     val state: Value<State>
     val downloadUtils: IDownloadUtils
-    val videoPlayerPool: VideoPlayerPool
     fun onBackClicked()
     fun onFontSizeChanged(size: Float)
     fun onLetterSpacingChanged(size: Float)
@@ -167,7 +165,6 @@ class DefaultChatSettingsComponent(
     override val downloadUtils: IDownloadUtils = container.utils.downloadUtils()
     private val settingsRepository: SettingsRepository = container.repositories.settingsRepository
     private val stickerRepository: StickerRepository = container.repositories.stickerRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
     private val distrManager: DistrManager = container.utils.distrManager()
     private val assetsManager: AssetsManager = container.utils.assetsManager()
 

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
@@ -122,8 +122,7 @@ fun ChatSettingsContent(component: ChatSettingsComponent) {
                     blurIntensity = state.wallpaperBlurIntensity,
                     dimming = state.wallpaperDimming,
                     isGrayscale = state.isWallpaperGrayscale,
-                    downloadUtils = component.downloadUtils,
-                    videoPlayerPool = component.videoPlayerPool
+                    downloadUtils = component.downloadUtils
                 )
             }
 
@@ -789,8 +788,7 @@ fun ChatSettingsContent(component: ChatSettingsComponent) {
                 ChatListPreview(
                     messageLines = state.chatListMessageLines,
                     showPhotos = state.showChatListPhotos,
-                    position = ItemPosition.TOP,
-                    videoPlayerPool = component.videoPlayerPool
+                    position = ItemPosition.TOP
                 )
 
                 Surface(

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/components/ChatListPreview.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/components/ChatListPreview.kt
@@ -18,13 +18,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.core.ui.ItemPosition
 
 @Composable
 fun ChatListPreview(
     messageLines: Int,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier,
     showPhotos: Boolean = true,
     position: ItemPosition = ItemPosition.STANDALONE
@@ -83,8 +81,7 @@ fun ChatListPreview(
                     time = stringResource(R.string.preview_time_konata),
                     lines = messageLines,
                     showPhotos = showPhotos,
-                    isKonata = true,
-                    videoPlayerPool = videoPlayerPool
+                    isKonata = true
                 )
                 Spacer(modifier = Modifier.height(12.dp))
                 PreviewChatItem(
@@ -93,8 +90,7 @@ fun ChatListPreview(
                     time = stringResource(R.string.preview_time_kagami),
                     lines = messageLines,
                     showPhotos = showPhotos,
-                    isKonata = false,
-                    videoPlayerPool = videoPlayerPool
+                    isKonata = false
                 )
             }
         }
@@ -112,8 +108,7 @@ private fun PreviewChatItem(
     time: String,
     lines: Int,
     showPhotos: Boolean,
-    isKonata: Boolean,
-    videoPlayerPool: VideoPlayerPool
+    isKonata: Boolean
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -129,8 +124,7 @@ private fun PreviewChatItem(
                     path = if (isKonata) "local" else null,
                     name = name,
                     size = 48.dp,
-                    isLocal = isKonata,
-                    videoPlayerPool = videoPlayerPool
+                    isLocal = isKonata
                 )
 
                 Spacer(modifier = Modifier.width(12.dp))

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/components/ChatSettingsPreview.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/components/ChatSettingsPreview.kt
@@ -23,7 +23,6 @@ import org.monogram.domain.models.*
 import org.monogram.presentation.R
 import org.monogram.presentation.core.util.IDownloadUtils
 import org.monogram.presentation.features.chats.currentChat.components.MessageBubbleContainer
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import java.io.File
 
 @Composable
@@ -39,8 +38,7 @@ fun ChatSettingsPreview(
     dimming: Int = 0,
     isGrayscale: Boolean = false,
     modifier: Modifier = Modifier,
-    downloadUtils: IDownloadUtils,
-    videoPlayerPool: VideoPlayerPool
+    downloadUtils: IDownloadUtils
 ) {
     Column(modifier = modifier) {
         Text(
@@ -234,8 +232,7 @@ fun ChatSettingsPreview(
                         onPhotoClick = onPhotoClick,
                         onReplyClick = onReplyClick,
                         toProfile = toProfile,
-                        downloadUtils = downloadUtils,
-                        videoPlayerPool = videoPlayerPool
+                        downloadUtils = downloadUtils
                     )
                 }
             }

--- a/presentation/src/main/java/org/monogram/presentation/settings/folders/FolderDialog.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/folders/FolderDialog.kt
@@ -28,7 +28,6 @@ import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.ui.ItemPosition
 import org.monogram.presentation.features.chats.chatList.components.SectionHeader
 import org.monogram.presentation.features.chats.chatList.components.SettingsTextField
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -40,7 +39,6 @@ fun FolderDialog(
     initialSelectedChatIds: List<Long> = emptyList(),
     availableChats: List<ChatModel> = emptyList(),
     confirmButtonText: String,
-    videoPlayerPool: VideoPlayerPool,
     isEditMode: Boolean = false,
     onDismiss: () -> Unit,
     onConfirm: (String, String?, List<Long>) -> Unit,
@@ -195,8 +193,7 @@ fun FolderDialog(
                                 path = chat.avatarPath,
                                 fallbackPath = chat.personalAvatarPath,
                                 name = chat.title,
-                                size = 36.dp,
-                                videoPlayerPool = videoPlayerPool
+                                size = 36.dp
                             )
                             Spacer(Modifier.width(12.dp))
                             Text(

--- a/presentation/src/main/java/org/monogram/presentation/settings/folders/FoldersComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/folders/FoldersComponent.kt
@@ -10,12 +10,10 @@ import org.monogram.domain.models.ChatModel
 import org.monogram.domain.models.FolderModel
 import org.monogram.domain.repository.ChatsListRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 interface FoldersComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
     fun onBackClicked()
     fun onCreateFolderClicked()
     fun onFolderClicked(folderId: Int)
@@ -42,7 +40,6 @@ class DefaultFoldersComponent(
 ) : FoldersComponent, AppComponentContext by context {
 
     private val repository: ChatsListRepository = container.repositories.chatsListRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state = MutableValue(FoldersComponent.State())
     override val state: Value<FoldersComponent.State> = _state

--- a/presentation/src/main/java/org/monogram/presentation/settings/folders/FoldersContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/folders/FoldersContent.kt
@@ -137,8 +137,7 @@ fun FoldersContent(component: FoldersComponent) {
             confirmButtonText = stringResource(R.string.folders_create),
             onDismiss = { defaultComponent?.dismissDialog() },
             onConfirm = component::onAddFolder,
-            onSearchChats = component::onSearchChats,
-            videoPlayerPool = component.videoPlayerPool
+            onSearchChats = component::onSearchChats
         )
     }
 
@@ -161,8 +160,7 @@ fun FoldersContent(component: FoldersComponent) {
                 )
             },
             onDelete = { component.onDeleteFolder(state.selectedFolder!!.id) },
-            onSearchChats = component::onSearchChats,
-            videoPlayerPool = component.videoPlayerPool
+            onSearchChats = component::onSearchChats
         )
     }
 }

--- a/presentation/src/main/java/org/monogram/presentation/settings/notifications/NotificationsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/notifications/NotificationsComponent.kt
@@ -17,12 +17,10 @@ import org.monogram.domain.repository.SettingsRepository
 import org.monogram.domain.repository.SettingsRepository.TdNotificationScope
 import org.monogram.presentation.core.util.AppPreferences
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 interface NotificationsComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
     val childStack: Value<ChildStack<*, Child>>
 
     fun onBackClicked()
@@ -81,7 +79,6 @@ class DefaultNotificationsComponent(
 
     private val appPreferences: AppPreferences = container.preferences.appPreferences
     private val settingsRepository: SettingsRepository = container.repositories.settingsRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
     private val distrManager: DistrManager = container.utils.distrManager()
 
     private val scope = componentScope

--- a/presentation/src/main/java/org/monogram/presentation/settings/notifications/NotificationsExceptionsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/notifications/NotificationsExceptionsContent.kt
@@ -27,7 +27,6 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import org.monogram.domain.models.ChatModel
 import org.monogram.domain.repository.SettingsRepository.TdNotificationScope
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.core.ui.ItemPosition
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -215,8 +214,7 @@ fun NotificationsExceptionsContent(
                         ExceptionItem(
                             chat = chat,
                             position = position,
-                            onClick = { selectedChat = chat },
-                            videoPlayerPool = component.videoPlayerPool
+                            onClick = { selectedChat = chat }
                         )
                     }
 
@@ -242,7 +240,6 @@ fun NotificationsExceptionsContent(
                 component.onChatExceptionToggled(chat.id, chat.isMuted)
                 selectedChat = null
             },
-            videoPlayerPool = component.videoPlayerPool,
             onRemoveException = {
                 component.onChatExceptionReset(chat.id)
                 selectedChat = null
@@ -297,7 +294,6 @@ private fun EmptyExceptionsPlaceholder(modifier: Modifier = Modifier) {
 @Composable
 private fun ExceptionActionsSheet(
     chat: ChatModel,
-    videoPlayerPool: VideoPlayerPool,
     onDismiss: () -> Unit,
     onToggleMute: () -> Unit,
     onRemoveException: () -> Unit
@@ -334,8 +330,7 @@ private fun ExceptionActionsSheet(
                     path = chat.avatarPath,
                     fallbackPath = chat.personalAvatarPath,
                     name = chat.title,
-                    size = 48.dp,
-                    videoPlayerPool = videoPlayerPool
+                    size = 48.dp
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 Column {
@@ -430,7 +425,6 @@ private fun ExceptionActionsSheet(
 private fun ExceptionItem(
     chat: ChatModel,
     position: ItemPosition,
-    videoPlayerPool: VideoPlayerPool,
     onClick: () -> Unit
 ) {
     val cornerRadius = 24.dp
@@ -469,8 +463,7 @@ private fun ExceptionItem(
                 path = chat.avatarPath,
                 fallbackPath = chat.personalAvatarPath,
                 name = chat.title,
-                size = 44.dp,
-                videoPlayerPool = videoPlayerPool
+                size = 44.dp
             )
             Spacer(modifier = Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {

--- a/presentation/src/main/java/org/monogram/presentation/settings/privacy/BlockedUsersComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/privacy/BlockedUsersComponent.kt
@@ -8,12 +8,10 @@ import org.monogram.domain.models.UserModel
 import org.monogram.domain.repository.PrivacyRepository
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 interface BlockedUsersComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
     fun onBackClicked()
     fun onUnblockUserClicked(userId: Long)
     fun onAddBlockedUserClicked()
@@ -34,7 +32,6 @@ class DefaultBlockedUsersComponent(
 
     private val privacyRepository: PrivacyRepository = container.repositories.privacyRepository
     private val userRepository: UserRepository = container.repositories.userRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state = MutableValue(BlockedUsersComponent.State())
     override val state: Value<BlockedUsersComponent.State> = _state

--- a/presentation/src/main/java/org/monogram/presentation/settings/privacy/BlockedUsersContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/privacy/BlockedUsersContent.kt
@@ -31,7 +31,6 @@ import org.monogram.domain.models.UserModel
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.ui.ItemPosition
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -144,8 +143,7 @@ fun BlockedUsersContent(component: BlockedUsersComponent) {
                                     user = user,
                                     position = position,
                                     onUnblock = { component.onUnblockUserClicked(user.id) },
-                                    onClick = { component.onUserClicked(user.id) },
-                                    videoPlayerPool = component.videoPlayerPool
+                                    onClick = { component.onUserClicked(user.id) }
                                 )
                             }
                         }
@@ -160,7 +158,6 @@ fun BlockedUsersContent(component: BlockedUsersComponent) {
 fun BlockedUserItem(
     user: UserModel,
     position: ItemPosition,
-    videoPlayerPool: VideoPlayerPool,
     onUnblock: () -> Unit,
     onClick: () -> Unit
 ) {
@@ -220,8 +217,7 @@ fun BlockedUserItem(
                 path = user.avatarPath,
                 fallbackPath = user.personalAvatarPath,
                 name = user.firstName.ifBlank { "D" },
-                size = 40.dp,
-                videoPlayerPool = videoPlayerPool
+                size = 40.dp
             )
             Spacer(modifier = Modifier.width(16.dp))
             Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {

--- a/presentation/src/main/java/org/monogram/presentation/settings/privacy/PrivacySettingComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/privacy/PrivacySettingComponent.kt
@@ -15,12 +15,10 @@ import org.monogram.domain.repository.PrivacyRepository
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.R
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 interface PrivacySettingComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
     fun onBackClicked()
     fun onPrivacyValueChanged(value: PrivacyValue)
     fun onSearchPrivacyValueChanged(value: PrivacyValue)
@@ -53,7 +51,6 @@ class DefaultPrivacySettingComponent(
     private val userRepository: UserRepository = container.repositories.userRepository
     private val privacyRepository: PrivacyRepository = container.repositories.privacyRepository
     private val chatsRepository: ChatsListRepository = container.repositories.chatsListRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state =
         MutableValue(PrivacySettingComponent.State(titleRes = getTitleRes(privacyKey), privacyKey = privacyKey))

--- a/presentation/src/main/java/org/monogram/presentation/settings/privacy/PrivacySettingContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/privacy/PrivacySettingContent.kt
@@ -30,7 +30,6 @@ import org.monogram.domain.models.UserStatusType
 import org.monogram.domain.repository.PrivacyKey
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.core.ui.ItemPosition
 import org.monogram.presentation.core.ui.SettingsTile
 
@@ -192,8 +191,7 @@ fun PrivacySettingContent(component: PrivacySettingComponent) {
                             user = user,
                             position = position,
                             onClick = { component.onUserClicked(user.id) },
-                            onRemove = { component.onRemoveUser(user.id, true) },
-                            videoPlayerPool = component.videoPlayerPool
+                            onRemove = { component.onRemoveUser(user.id, true) }
                         )
                         currentIndex++
                     }
@@ -207,8 +205,7 @@ fun PrivacySettingContent(component: PrivacySettingComponent) {
                         ExceptionChatItem(
                             chat = chat,
                             position = position,
-                            onRemove = { component.onRemoveChat(chat.id, true) },
-                            videoPlayerPool = component.videoPlayerPool
+                            onRemove = { component.onRemoveChat(chat.id, true) }
                         )
                         currentIndex++
                     }
@@ -232,8 +229,7 @@ fun PrivacySettingContent(component: PrivacySettingComponent) {
                             user = user,
                             position = position,
                             onClick = { component.onUserClicked(user.id) },
-                            onRemove = { component.onRemoveUser(user.id, false) },
-                            videoPlayerPool = component.videoPlayerPool
+                            onRemove = { component.onRemoveUser(user.id, false) }
                         )
                         currentIndex++
                     }
@@ -247,8 +243,7 @@ fun PrivacySettingContent(component: PrivacySettingComponent) {
                         ExceptionChatItem(
                             chat = chat,
                             position = position,
-                            onRemove = { component.onRemoveChat(chat.id, false) },
-                            videoPlayerPool = component.videoPlayerPool
+                            onRemove = { component.onRemoveChat(chat.id, false) }
                         )
                         currentIndex++
                     }
@@ -263,7 +258,6 @@ fun PrivacySettingContent(component: PrivacySettingComponent) {
 fun ExceptionUserItem(
     user: UserModel,
     position: ItemPosition,
-    videoPlayerPool: VideoPlayerPool,
     onClick: () -> Unit,
     onRemove: () -> Unit
 ) {
@@ -322,8 +316,7 @@ fun ExceptionUserItem(
                 fallbackPath = user.personalAvatarPath,
                 name = user.firstName.ifBlank { "D" },
                 size = 40.dp,
-                isOnline = user.userStatus == UserStatusType.ONLINE,
-                videoPlayerPool = videoPlayerPool
+                isOnline = user.userStatus == UserStatusType.ONLINE
             )
             Spacer(modifier = Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {
@@ -341,7 +334,6 @@ fun ExceptionUserItem(
 fun ExceptionChatItem(
     chat: ChatModel,
     position: ItemPosition,
-    videoPlayerPool: VideoPlayerPool,
     onRemove: () -> Unit
 ) {
     val cornerRadius = 24.dp
@@ -379,8 +371,7 @@ fun ExceptionChatItem(
                 path = chat.avatarPath,
                 fallbackPath = chat.personalAvatarPath,
                 name = chat.title.take(1),
-                size = 40.dp,
-                videoPlayerPool = videoPlayerPool
+                size = 40.dp
             )
             Spacer(modifier = Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {

--- a/presentation/src/main/java/org/monogram/presentation/settings/privacy/userSelection/DefaultUserSelectionComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/privacy/userSelection/DefaultUserSelectionComponent.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultUserSelectionComponent(
@@ -19,7 +18,6 @@ class DefaultUserSelectionComponent(
 ) : UserSelectionComponent, AppComponentContext by context {
 
     private val userRepository: UserRepository = container.repositories.userRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state = MutableValue(UserSelectionComponent.State())
     override val state: Value<UserSelectionComponent.State> = _state

--- a/presentation/src/main/java/org/monogram/presentation/settings/privacy/userSelection/UserSelectionComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/privacy/userSelection/UserSelectionComponent.kt
@@ -2,11 +2,9 @@ package org.monogram.presentation.settings.privacy.userSelection
 
 import com.arkivanov.decompose.value.Value
 import org.monogram.domain.models.UserModel
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface UserSelectionComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
     fun onBackClicked()
     fun onSearchQueryChanged(query: String)
     fun onUserClicked(userId: Long)

--- a/presentation/src/main/java/org/monogram/presentation/settings/privacy/userSelection/UserSelectionContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/privacy/userSelection/UserSelectionContent.kt
@@ -27,7 +27,6 @@ import org.monogram.domain.models.UserModel
 import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.ui.SettingsGroup
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -118,8 +117,7 @@ fun UserSelectionContent(component: UserSelectionComponent) {
                                         UserSelectionItem(
                                             user = user,
                                             onClick = { component.onUserClicked(user.id) },
-                                            modifier = Modifier.animateItem(),
-                                            videoPlayerPool = component.videoPlayerPool
+                                            modifier = Modifier.animateItem()
                                         )
                                     }
                                 }
@@ -136,7 +134,6 @@ fun UserSelectionContent(component: UserSelectionComponent) {
 fun UserSelectionItem(
     user: UserModel,
     onClick: () -> Unit,
-    videoPlayerPool: VideoPlayerPool,
     modifier: Modifier = Modifier
 ) {
     val deletedText = stringResource(R.string.privacy_user_deleted)
@@ -186,8 +183,7 @@ fun UserSelectionItem(
                 path = user.avatarPath,
                 fallbackPath = user.personalAvatarPath,
                 name = user.firstName.ifBlank { "D" },
-                size = 40.dp,
-                videoPlayerPool = videoPlayerPool
+                size = 40.dp
             )
         },
         modifier = modifier.clickable(onClick = onClick),

--- a/presentation/src/main/java/org/monogram/presentation/settings/profile/DefaultEditProfileComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/profile/DefaultEditProfileComponent.kt
@@ -10,7 +10,6 @@ import org.monogram.domain.repository.ChatsListRepository
 import org.monogram.domain.repository.LocationRepository
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultEditProfileComponent(
@@ -21,7 +20,6 @@ class DefaultEditProfileComponent(
     private val userRepository: UserRepository = container.repositories.userRepository
     private val chatsListRepository: ChatsListRepository = container.repositories.chatsListRepository
     private val locationRepository: LocationRepository = container.repositories.locationRepository
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state = MutableValue(EditProfileComponent.State())
     override val state: Value<EditProfileComponent.State> = _state

--- a/presentation/src/main/java/org/monogram/presentation/settings/profile/EditProfileComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/profile/EditProfileComponent.kt
@@ -5,11 +5,9 @@ import org.monogram.domain.models.BirthdateModel
 import org.monogram.domain.models.BusinessOpeningHoursModel
 import org.monogram.domain.models.ChatModel
 import org.monogram.domain.models.UserModel
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface EditProfileComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBack()
     fun onUpdateFirstName(firstName: String)

--- a/presentation/src/main/java/org/monogram/presentation/settings/profile/EditProfileContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/profile/EditProfileContent.kt
@@ -826,7 +826,6 @@ fun EditProfileContent(component: EditProfileComponent) {
                                 path = state.avatarPath,
                                 name = state.firstName,
                                 size = 100.dp,
-                                videoPlayerPool = component.videoPlayerPool,
                                 onClick = {
                                     photoPickerLauncher.launch(
                                         PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
@@ -980,8 +979,7 @@ fun EditProfileContent(component: EditProfileComponent) {
                                         path = chat.avatarPath,
                                         fallbackPath = chat.personalAvatarPath,
                                         name = chat.title,
-                                        size = 40.dp,
-                                        videoPlayerPool = component.videoPlayerPool
+                                        size = 40.dp
                                     )
                                     Spacer(modifier = Modifier.width(12.dp))
                                     Column {

--- a/presentation/src/main/java/org/monogram/presentation/settings/settings/DefaultSettingsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/settings/DefaultSettingsComponent.kt
@@ -15,7 +15,6 @@ import org.monogram.domain.repository.AppPreferencesProvider
 import org.monogram.domain.repository.ExternalNavigator
 import org.monogram.domain.repository.UserRepository
 import org.monogram.presentation.core.util.componentScope
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 import org.monogram.presentation.root.AppComponentContext
 
 class DefaultSettingsComponent(
@@ -40,7 +39,6 @@ class DefaultSettingsComponent(
     private val externalNavigator: ExternalNavigator = container.utils.externalNavigator()
     private val domainManager: DomainManager = container.utils.domainManager()
     private val preferences: AppPreferencesProvider = container.preferences.appPreferences
-    override val videoPlayerPool: VideoPlayerPool = container.utils.videoPlayerPool
 
     private val _state = MutableValue(SettingsComponent.State())
     override val state: Value<SettingsComponent.State> = _state

--- a/presentation/src/main/java/org/monogram/presentation/settings/settings/SettingsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/settings/SettingsComponent.kt
@@ -2,11 +2,9 @@ package org.monogram.presentation.settings.settings
 
 import com.arkivanov.decompose.value.Value
 import org.monogram.domain.models.UserModel
-import org.monogram.presentation.features.chats.currentChat.components.VideoPlayerPool
 
 interface SettingsComponent {
     val state: Value<State>
-    val videoPlayerPool: VideoPlayerPool
 
     fun onBackClicked()
     fun onEditProfileClicked()

--- a/presentation/src/main/java/org/monogram/presentation/settings/settings/SettingsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/settings/SettingsContent.kt
@@ -623,7 +623,6 @@ fun SettingsContent(component: SettingsComponent) {
                                     start = sidePadding,
                                     end = sidePadding
                                 ),
-                                videoPlayerPool = component.videoPlayerPool,
                                 onStatusClick = {
                                     statusAnchorBounds =
                                         headerStatusAnchorBounds ?: statusAnchorBounds


### PR DESCRIPTION
Refactor the codebase to provide `VideoPlayerPool` via `LocalVideoPlayerPool` instead of passing it explicitly through multiple layers of Composable functions and component interfaces.

Key changes:
- Created `LocalVideoPlayerPool` in `CompositionLocal.kt`.
- Updated `MainActivity` and `AppThemeContainer` to provide the pool instance.
- Removed `videoPlayerPool` parameter from dozens of UI components (Avatars, Message Bubbles, Grids, Sheets, etc.).
- Removed `videoPlayerPool` property from various component interfaces (e.g., `ChatComponent`, `ProfileComponent`, `SettingsComponent`).
- Updated `VideoStickerPlayer`, `AvatarPlayer`, and `VideoPlayerPool` to access the pool via `LocalVideoPlayerPool.current` or via updated constructor injection in DI.
- Cleaned up unused imports and reorganized parameters in affected Composable functions.