### PR TITLE
feat: gallery video duration

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/features/gallery/GalleryMediaQueries.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/gallery/GalleryMediaQueries.kt
@@ -33,7 +33,7 @@ fun queryImages(context: Context): List<GalleryMediaItem> {
                         cursor.getLong(idColumn)
                     ),
                     dateAdded = cursor.getLong(dateColumn),
-                    isVideo = false,
+                    duration = 0,
                     bucketName = bucket,
                     relativePath = relative,
                     isCamera = isCameraBucket(bucket, relative),
@@ -51,7 +51,8 @@ fun queryVideos(context: Context): List<GalleryMediaItem> {
         MediaStore.Video.Media._ID,
         MediaStore.Video.Media.DATE_ADDED,
         MediaStore.Video.Media.BUCKET_DISPLAY_NAME,
-        MediaStore.Video.Media.RELATIVE_PATH
+        MediaStore.Video.Media.RELATIVE_PATH,
+        MediaStore.Video.Media.DURATION
     )
     context.contentResolver.query(
         MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
@@ -64,6 +65,7 @@ fun queryVideos(context: Context): List<GalleryMediaItem> {
         val dateColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DATE_ADDED)
         val bucketColumn = cursor.getColumnIndex(MediaStore.Video.Media.BUCKET_DISPLAY_NAME)
         val relColumn = cursor.getColumnIndex(MediaStore.Video.Media.RELATIVE_PATH)
+        val durationColumn = cursor.getColumnIndex(MediaStore.Video.Media.DURATION)
         while (cursor.moveToNext()) {
             val bucket = if (bucketColumn != -1) cursor.getString(bucketColumn).orEmpty() else ""
             val relative = if (relColumn != -1) cursor.getString(relColumn).orEmpty() else ""
@@ -74,7 +76,7 @@ fun queryVideos(context: Context): List<GalleryMediaItem> {
                         cursor.getLong(idColumn)
                     ),
                     dateAdded = cursor.getLong(dateColumn),
-                    isVideo = true,
+                    duration = cursor.getLong(durationColumn),
                     bucketName = bucket,
                     relativePath = relative,
                     isCamera = isCameraBucket(bucket, relative),

--- a/presentation/src/main/java/org/monogram/presentation/features/gallery/GalleryModels.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/gallery/GalleryModels.kt
@@ -18,9 +18,12 @@ sealed class BucketFilter(val key: String) {
 data class GalleryMediaItem(
     val uri: Uri,
     val dateAdded: Long,
-    val isVideo: Boolean,
+    val duration: Long,
     val bucketName: String,
     val relativePath: String,
     val isCamera: Boolean,
     val isScreenshot: Boolean
-)
+) {
+    val isVideo: Boolean
+        get() = duration > 0
+}

--- a/presentation/src/main/java/org/monogram/presentation/features/gallery/components/GalleryMediaGrid.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/gallery/components/GalleryMediaGrid.kt
@@ -29,6 +29,19 @@ import coil3.compose.AsyncImage
 import org.monogram.presentation.R
 import org.monogram.presentation.features.gallery.GalleryMediaItem
 
+private fun formatDuration(ms: Long): String {
+    val sec = ms / 1000
+    val h = sec / 3600
+    val m = (sec % 3600) / 60
+    val s = sec % 60
+
+    return if (h > 0) {
+        "%d:%02d:%02d".format(h, m, s)
+    } else {
+        "%02d:%02d".format(m, s)
+    }
+}
+
 @Composable
 fun GalleryGrid(
     media: List<GalleryMediaItem>,
@@ -97,7 +110,7 @@ fun GalleryGrid(
                         color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f)
                     ) {
                         Text(
-                            text = stringResource(R.string.media_type_video),
+                            text = formatDuration(item.duration),
                             style = MaterialTheme.typography.labelSmall,
                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
                         )


### PR DESCRIPTION
resolves #136

works for videos under an hour, but i was unable to test it on long videos for some reason. 

both official telegram client and monogram refuse to index these files. official telegram application shows them as "00:00" in duration, and monogram doesn't show the duration at all - the duration is probably 0 in this case.

i don't know how the app should behave in this scenario (show zero duration, don't show duration, show unknown duration), so i am marking this as a draft for now. if we need to distinguish between zero duration and non-videos, then default duration should be set to a negative value