### PR TITLE
Support building without FCM config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.android.build.VariantOutput
 import com.android.build.gradle.internal.api.ApkVariantOutputImpl
 import com.google.android.gms.oss.licenses.plugin.DependencyTask
+import com.google.gms.googleservices.GoogleServicesPlugin
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -124,4 +125,8 @@ tasks.withType(DependencyTask::class.java).configureEach {
             }
         }
     }
+}
+
+googleServices {
+    missingGoogleServicesStrategy = GoogleServicesPlugin.MissingGoogleServicesStrategy.WARN
 }

--- a/app/src/main/java/org/monogram/app/App.kt
+++ b/app/src/main/java/org/monogram/app/App.kt
@@ -46,7 +46,7 @@ class App : Application(), SingletonImageLoader.Factory {
         initKoin()
         initTdLib()
         initMapLibre()
-        checkGmsAvailability()
+        checkPushAvailability()
     }
 
     private fun initCrashHandler() {
@@ -90,12 +90,13 @@ class App : Application(), SingletonImageLoader.Factory {
         MapLibre.getInstance(this, null, WellKnownTileServer.MapLibre)
     }
 
-    private fun checkGmsAvailability() {
+    private fun checkPushAvailability() {
         val distrManager = get<DistrManager>()
         val isGmsAvailable = distrManager.isGmsAvailable()
+        val isFcmAvailable = distrManager.isFcmAvailable()
 
         val prefs = get<AppPreferencesProvider>()
-        if (!isGmsAvailable && prefs.pushProvider.value == PushProvider.FCM) {
+        if (!(isGmsAvailable && isFcmAvailable) && prefs.pushProvider.value == PushProvider.FCM) {
             prefs.setPushProvider(PushProvider.GMS_LESS)
         }
     }

--- a/app/src/main/java/org/monogram/app/di/DistrManagerImpl.kt
+++ b/app/src/main/java/org/monogram/app/di/DistrManagerImpl.kt
@@ -4,11 +4,16 @@ import android.content.Context
 import android.os.Build
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.FirebaseApp
 import org.monogram.domain.managers.DistrManager
 
 class DistrManagerImpl(private val context: Context) : DistrManager {
     override fun isGmsAvailable(): Boolean {
         return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
+    }
+
+    override fun isFcmAvailable(): Boolean {
+        return FirebaseApp.getApps(context).isNotEmpty()
     }
 
     override fun isInstalledFromGooglePlay(): Boolean {

--- a/domain/src/main/java/org/monogram/domain/managers/DistrManager.kt
+++ b/domain/src/main/java/org/monogram/domain/managers/DistrManager.kt
@@ -2,5 +2,6 @@ package org.monogram.domain.managers
 
 interface DistrManager {
     fun isGmsAvailable(): Boolean
+    fun isFcmAvailable(): Boolean
     fun isInstalledFromGooglePlay(): Boolean
 }


### PR DESCRIPTION
This PR adds support for building the app without google-services.json.

The motivation for this is primarily that I don't use GMS on my device and am just too lazy to configure Firebase. This may also be useful for #40.

(Good app, thank you!)