### PR TITLE
fix: don't show pinned messages

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentTopBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/currentChat/chatContent/ChatContentTopBar.kt
@@ -341,7 +341,9 @@ fun ChatContentTopBar(
             }
         }
 
-        val showPinned = state.pinnedMessage != null && !isSelectionMode && state.rootMessage == null
+        // FIXME: tracker - https://github.com/monogram-android/monogram/issues/145
+        // val showPinned = state.pinnedMessage != null && !isSelectionMode && state.rootMessage == null
+        val showPinned = false
         AnimatedVisibility(
             visible = showPinned,
             enter = expandVertically(),


### PR DESCRIPTION
hotfix for #145

though pins are essential, because this is a potential destructive behavior to the user's data, i think this should be avoided asap

this change can be found easily later by searching `FIXME` in the codebase (it's the only fixme aside from the third-party libs)