### PR TITLE
Update project to AGP 9.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ import com.google.gms.googleservices.GoogleServicesPlugin
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.google.oss.licenses)
     alias(libs.plugins.google.services)
@@ -41,6 +40,9 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+            buildFeatures {
+                resValues = true
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -51,6 +53,9 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             isMinifyEnabled = false
+            buildFeatures {
+                resValues = true
+            }
             resValue("string", "app_name", "MonoGram Debug")
         }
     }

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.test")
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.androidx.baselineprofile)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import java.util.Properties
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.lint) apply false
     alias(libs.plugins.android.library) apply false

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.*
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 # Plugins
-agp = "8.12.0"
+agp = "9.1.0"
 kotlin = "2.3.10"
 google-services = "4.4.4"
 ossLicensesPlugin = "0.10.10"
 ksp = "2.3.6"
-baselineprofile = "1.4.1"
+baselineprofile = "1.5.0-alpha05"
 
 # AndroidX
 androidx-activityCompose = "1.12.4"
@@ -186,7 +186,6 @@ koin = [
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-oss-licenses = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "ossLicensesPlugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.compose)
     id("kotlin-parcelize")


### PR DESCRIPTION
Most prominent change is built-in Kotlin which removes the kotlin-android dependency.
Additionally, gradle was updated to 9.3.1 to ensure compatibility.
One minor caveat is that androidx.baselineprofile has only recently adapted to AGP, so it currently requires an alpha version

For a complete list of changes, see: https://developer.android.com/build/releases/agp-9-0-0-release-notes