### PR TITLE
fix: gradle app version name

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
         minSdk = 25
         targetSdk = 36
         versionCode = 5
-        versionName = "1.0"
+        versionName = "0.0.5"
     }
 
     splits {


### PR DESCRIPTION
matches current git tag name and release version

i was able to successfully install the app even after previous higher version, and versions in both system settings and application settings are correct