### PR TITLE
fix: handle missing microphone permission for voice recording

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/ChatInputBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/ChatInputBar.kt
@@ -311,11 +311,16 @@ fun ChatInputBar(
         }
     }
 
-    val voiceRecorder = rememberVoiceRecorder { path, duration, waveform ->
-        if (!canSendVoice || isSlowModeActive) return@rememberVoiceRecorder
-        actions.onSendVoice(path, duration, waveform)
-        activateSlowModeCooldown()
-    }
+    val voiceRecorder = rememberVoiceRecorder(
+        onRecordingFinished = { path, duration, waveform ->
+            if (!canSendVoice || isSlowModeActive) return@rememberVoiceRecorder
+            actions.onSendVoice(path, duration, waveform)
+            activateSlowModeCooldown()
+        },
+        onPermissionDenied = {
+            microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    )
     val maxMessageLength by remember(
         state.pendingMediaPaths,
         state.pendingDocumentPaths,
@@ -614,6 +619,9 @@ fun ChatInputBar(
         hasCameraPermission.value = granted
         if (granted) showCamera = true
     }
+    val microphonePermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { }
     val documentsPickerLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments()
     ) { uris ->
@@ -1093,4 +1101,5 @@ fun ChatInputBar(
             }
         )
     }
+
 }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/inputbar/VoiceRecorder.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/inputbar/VoiceRecorder.kt
@@ -14,13 +14,18 @@ import kotlin.math.log10
 
 @Composable
 fun rememberVoiceRecorder(
-    onRecordingFinished: (String, Int, ByteArray) -> Unit
+    onRecordingFinished: (String, Int, ByteArray) -> Unit,
+    onPermissionDenied: () -> Unit = {}
 ): VoiceRecorderState {
     val context = LocalContext.current
     val state = remember { VoiceRecorderState(context) }
 
     LaunchedEffect(onRecordingFinished) {
         state.onRecordingFinished = onRecordingFinished
+    }
+
+    LaunchedEffect(onPermissionDenied) {
+        state.onPermissionDenied = onPermissionDenied
     }
 
     DisposableEffect(Unit) {
@@ -55,6 +60,7 @@ class VoiceRecorderState(private val context: Context) {
     private var startTime = 0L
 
     var onRecordingFinished: ((String, Int, ByteArray) -> Unit)? = null
+    var onPermissionDenied: (() -> Unit)? = null
 
     @Suppress("DEPRECATION")
     fun startRecording() {
@@ -65,7 +71,7 @@ class VoiceRecorderState(private val context: Context) {
                 Manifest.permission.RECORD_AUDIO
             ) != PackageManager.PERMISSION_GRANTED
         ) {
-            // TODO: Request permission
+            onPermissionDenied?.invoke()
             return
         }
 


### PR DESCRIPTION
Starting a voice recording without RECORD_AUDIO permission used to fail silently. The composer would just do nothing, which made the flow feel stuck.

This change routes that case through the chat input screen so the app can ask for microphone permission directly instead of leaving the user with a dead tap. The recorder now exposes a permission-denied callback, and the chat bar uses it when recording cannot start.