### PR TITLE
Improve date display, forward timestamps, and group creation flow

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/ChatDateLabel.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/ChatDateLabel.kt
@@ -17,11 +17,34 @@ fun isTodayTimestamp(timestamp: Int, locale: Locale = Locale.getDefault()): Bool
 
 fun formatChatDayLabel(timestamp: Int, locale: Locale = Locale.getDefault()): String {
     val date = Date(timestamp.toLong() * 1000)
-    val calendar = Calendar.getInstance(locale)
-    val currentYear = calendar.get(Calendar.YEAR)
-    calendar.time = date
-    val messageYear = calendar.get(Calendar.YEAR)
+    val now = Calendar.getInstance(locale)
+    val msgCal = Calendar.getInstance(locale).apply { time = date }
 
-    val pattern = if (messageYear == currentYear) "d MMMM" else "d MMMM yyyy"
-    return SimpleDateFormat(pattern, locale).format(date)
+    val nowYear = now.get(Calendar.YEAR)
+    val nowDay = now.get(Calendar.DAY_OF_YEAR)
+    val msgYear = msgCal.get(Calendar.YEAR)
+    val msgDay = msgCal.get(Calendar.DAY_OF_YEAR)
+
+    if (nowYear == msgYear) {
+        val dayDiff = nowDay - msgDay
+        return when {
+            dayDiff == 0 -> "Today"
+            dayDiff == 1 -> "Yesterday"
+            dayDiff in 2..6 -> SimpleDateFormat("EEEE", locale).format(date)
+            else -> SimpleDateFormat("d MMMM", locale).format(date)
+        }
+    }
+
+    if (nowYear - msgYear == 1 && msgDay >= 359 && nowDay <= 6) {
+        val daysInMsgYear = msgCal.getActualMaximum(Calendar.DAY_OF_YEAR)
+        val dayDiff = (daysInMsgYear - msgDay) + nowDay
+        return when {
+            dayDiff == 0 -> "Today"
+            dayDiff == 1 -> "Yesterday"
+            dayDiff in 2..6 -> SimpleDateFormat("EEEE", locale).format(date)
+            else -> SimpleDateFormat("d MMMM yyyy", locale).format(date)
+        }
+    }
+
+    return SimpleDateFormat("d MMMM yyyy", locale).format(date)
 }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/ChatDateLabel.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/ChatDateLabel.kt
@@ -1,5 +1,7 @@
 package org.monogram.presentation.features.chats.conversation.ui
 
+import android.content.Context
+import org.monogram.presentation.R
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -15,7 +17,7 @@ fun isTodayTimestamp(timestamp: Int, locale: Locale = Locale.getDefault()): Bool
             calendar.get(Calendar.DAY_OF_YEAR) == todayDayOfYear
 }
 
-fun formatChatDayLabel(timestamp: Int, locale: Locale = Locale.getDefault()): String {
+fun formatChatDayLabel(timestamp: Int, context: Context, locale: Locale = Locale.getDefault()): String {
     val date = Date(timestamp.toLong() * 1000)
     val now = Calendar.getInstance(locale)
     val msgCal = Calendar.getInstance(locale).apply { time = date }
@@ -28,8 +30,8 @@ fun formatChatDayLabel(timestamp: Int, locale: Locale = Locale.getDefault()): St
     if (nowYear == msgYear) {
         val dayDiff = nowDay - msgDay
         return when {
-            dayDiff == 0 -> "Today"
-            dayDiff == 1 -> "Yesterday"
+            dayDiff == 0 -> context.getString(R.string.chat_date_today)
+            dayDiff == 1 -> context.getString(R.string.chat_date_yesterday)
             dayDiff in 2..6 -> SimpleDateFormat("EEEE", locale).format(date)
             else -> SimpleDateFormat("d MMMM", locale).format(date)
         }
@@ -39,8 +41,8 @@ fun formatChatDayLabel(timestamp: Int, locale: Locale = Locale.getDefault()): St
         val daysInMsgYear = msgCal.getActualMaximum(Calendar.DAY_OF_YEAR)
         val dayDiff = (daysInMsgYear - msgDay) + nowDay
         return when {
-            dayDiff == 0 -> "Today"
-            dayDiff == 1 -> "Yesterday"
+            dayDiff == 0 -> context.getString(R.string.chat_date_today)
+            dayDiff == 1 -> context.getString(R.string.chat_date_yesterday)
             dayDiff in 2..6 -> SimpleDateFormat("EEEE", locale).format(date)
             else -> SimpleDateFormat("d MMMM yyyy", locale).format(date)
         }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/DateSeparator.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/DateSeparator.kt
@@ -10,11 +10,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun DateSeparator(timestamp: Int) {
-    val text = formatChatDayLabel(timestamp)
+    val context = LocalContext.current
+    val text = formatChatDayLabel(timestamp, context)
     Box(
         modifier = Modifier
             .fillMaxWidth()

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentList.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentList.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -191,6 +192,7 @@ fun ChatContentList(
 ) {
     val isComments = state.isComments
     val appearance = state.toAppearanceConfig()
+    val context = LocalContext.current
     val density = LocalDensity.current
     val isScrolling by remember(scrollState) { derivedStateOf { scrollState.isScrollInProgress } }
     val latestState by rememberUpdatedState(state)
@@ -306,7 +308,7 @@ fun ChatContentList(
                     viewportTopOffset = viewportTopOffset
                 )
                 ?: return@derivedStateOf null
-            formatChatDayLabel(anchor.mainTimestamp())
+            formatChatDayLabel(anchor.mainTimestamp(), context)
         }
     }
 

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/ForwardContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/ForwardContent.kt
@@ -33,6 +33,7 @@ import org.monogram.domain.models.ForwardInfo
 import org.monogram.domain.models.ForwardOriginType
 import org.monogram.presentation.core.ui.Avatar
 import org.monogram.presentation.core.util.DateFormatManager
+import org.monogram.presentation.features.chats.conversation.ui.isTodayTimestamp
 
 @Composable
 fun ForwardContent(
@@ -132,9 +133,16 @@ fun ForwardContent(
                 )
 
                 if (forwardInfo.date > 0) {
+                    val forwardDateText = remember(forwardInfo.date, timeFormat) {
+                        if (isTodayTimestamp(forwardInfo.date)) {
+                            formatTime(forwardInfo.date, timeFormat)
+                        } else {
+                            formatForwardDate(forwardInfo.date, timeFormat)
+                        }
+                    }
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
-                        text = formatTime(forwardInfo.date, timeFormat),
+                        text = forwardDateText,
                         style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
                         color = contentColor.copy(alpha = 0.56f),
                         maxLines = 1

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/MessageUtils.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/MessageUtils.kt
@@ -55,6 +55,7 @@ import org.monogram.presentation.features.chats.conversation.ui.channel.formatVi
 import java.io.File
 import java.text.BreakIterator
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import kotlin.math.log10
@@ -66,6 +67,17 @@ val LocalLinkHandler = staticCompositionLocalOf<(String) -> Unit> {
 
 fun formatTime(ts: Int, timeFormat: String): String =
     SimpleDateFormat(timeFormat, Locale.getDefault()).format(Date(ts.toLong() * 1000))
+
+fun formatForwardDate(ts: Int, timeFormat: String): String {
+    val date = Date(ts.toLong() * 1000)
+    val locale = Locale.getDefault()
+    val cal = Calendar.getInstance(locale).apply { time = date }
+    val now = Calendar.getInstance(locale)
+    val datePattern = if (cal.get(Calendar.YEAR) == now.get(Calendar.YEAR)) "d MMM" else "d MMM yyyy"
+    val datePart = SimpleDateFormat(datePattern, locale).format(date)
+    val timePart = SimpleDateFormat(timeFormat, locale).format(date)
+    return "$datePart, $timePart"
+}
 
 fun formatDuration(seconds: Int): String {
     val m = seconds / 60

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/creation/DefaultNewChatComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/creation/DefaultNewChatComponent.kt
@@ -225,15 +225,13 @@ class DefaultNewChatComponent(
 
         when (currentState.step) {
             NewChatComponent.Step.GROUP_MEMBERS -> {
-                if (currentState.selectedUserIds.isNotEmpty()) {
-                    _state.update {
-                        it.copy(
-                            step = NewChatComponent.Step.GROUP_INFO,
-                            searchQuery = "",
-                            searchResults = emptyList(),
-                            validationError = null
-                        )
-                    }
+                _state.update {
+                    it.copy(
+                        step = NewChatComponent.Step.GROUP_INFO,
+                        searchQuery = "",
+                        searchResults = emptyList(),
+                        validationError = null
+                    )
                 }
             }
 

--- a/presentation/src/main/res/values/string.xml
+++ b/presentation/src/main/res/values/string.xml
@@ -2102,6 +2102,8 @@
     <string name="logs_media_unsupported">Unsupported message</string>
 
     <!-- Date and Formats -->
+    <string name="chat_date_today">Today</string>
+    <string name="chat_date_yesterday">Yesterday</string>
     <string name="format_duration">%1$02d:%2$02d</string>
 
     <!-- Views Count -->


### PR DESCRIPTION
Date separators in conversations currently show raw dates like "4 May" regardless of how recent the message is. This makes it hard to quickly gauge message recency at a glance.

This change updates `formatChatDayLabel()` to display relative labels — "Today", "Yesterday", or the weekday name — for messages within the past week, falling back to the full date for older messages. The year-boundary edge case (e.g. Dec 31 → Jan 1) is handled correctly.

Forwarded messages only showed the time of the original post, which loses context when the forward is from a different day. The forward header now shows the date alongside the time for non-today forwards (e.g. "3 May, 14:30").

Creating a group with only yourself was impossible because the member selection step required at least one other user before allowing the user to proceed. Both official Telegram clients allow this. The `isNotEmpty()` gate on the member list has been removed so users can continue to the group info screen with zero members selected.

Closes #87, #90, #149
