### PR TITLE
Fix #285 remove gray box behind avatar and fix settings header

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/core/ui/AvatarHeader.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/ui/AvatarHeader.kt
@@ -64,7 +64,7 @@ fun AvatarHeader(
         fallbackPath = fallbackPath?.takeIf { it.isNotBlank() } ?: cachedFallbackPath
     )
 
-    Box(modifier = combinedModifier) {
+    Box(modifier = combinedModifier.background(MaterialTheme.colorScheme.surfaceContainerHighest)) {
         val avatarFile = resolvedPath?.let { File(it) }
 
         if (avatarFile != null && avatarFile.exists()) {

--- a/presentation/src/main/java/org/monogram/presentation/settings/settings/SettingsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/settings/SettingsContent.kt
@@ -585,10 +585,9 @@ fun SettingsContent(component: SettingsComponent) {
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = dynamicContainerColorTopBar,
-                    scrolledContainerColor = Color.Transparent,
-
-                    )
+                    containerColor = Color.Transparent,
+                    scrolledContainerColor = Color.Transparent
+                )
             )
         }
     ) { padding ->


### PR DESCRIPTION
Made the settings top app bar transparent so it matches the profile screen and doesn't show a weird gray bar when collapsed. Also added a proper background to the AvatarHeader box so the placeholder avatar blends in instead of showing a gray rectangle.