### PR TITLE
fix(ui): fix time padding on messages (#262)

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/TextMessageBubble.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/TextMessageBubble.kt
@@ -124,11 +124,72 @@ fun TextMessageBubble(
 
                 val finalFontSize = if (renderData.isBigEmoji) fontSize * 5f else fontSize
 
+                val hasLinkPreview = showLinkPreviews && content.webPage != null
+                val useInlineTimestamp = !renderData.isBigEmoji && !hasLinkPreview
+
+                val timestampRow: @Composable () -> Unit = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (msg.editDate > 0) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = stringResource(R.string.info_edited),
+                                modifier = Modifier.size(14.dp),
+                                tint = timeColor
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                        }
+                        Text(
+                            text = formatTime(msg.date, timeFormat),
+                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
+                            color = timeColor
+                        )
+
+                        if (isOutgoing) {
+                            Spacer(modifier = Modifier.width(4.dp))
+                            MessageSendingStatusIcon(
+                                sendingState = msg.sendingState,
+                                isRead = msg.isRead,
+                                baseColor = timeColor,
+                                size = 14.dp
+                            )
+                        }
+                    }
+                }
+
                 if (renderData.isBigEmoji && renderData.bigEmojiItems.isNotEmpty()) {
                     BigEmojiContent(
                         items = renderData.bigEmojiItems,
                         sizeDp = finalFontSize,
                         modifier = Modifier.padding(bottom = 2.dp)
+                    )
+                } else if (useInlineTimestamp) {
+                    TextWithTimestampLayout(
+                        textContent = {
+                            MessageText(
+                                text = renderData.annotatedText,
+                                rawText = content.text,
+                                entities = content.entities,
+                                inlineContent = renderData.inlineContent,
+                                style = MaterialTheme.typography.bodyLarge.copy(
+                                    fontSize = finalFontSize.sp,
+                                    letterSpacing = letterSpacing.sp,
+                                    lineHeight = (finalFontSize * 1.1f).sp
+                                ),
+                                isOutgoing = isOutgoing,
+                                onSpoilerClick = { index ->
+                                    if (revealedSpoilers.contains(index)) {
+                                        revealedSpoilers.remove(index)
+                                    } else {
+                                        revealedSpoilers.add(index)
+                                    }
+                                },
+                                onClick = onClick,
+                                onLongClick = onLongClick
+                            )
+                        },
+                        timestampContent = timestampRow
                     )
                 } else {
                     MessageText(
@@ -155,7 +216,7 @@ fun TextMessageBubble(
                     )
                 }
 
-                if (showLinkPreviews) {
+                if (hasLinkPreview) {
                     content.webPage?.let { webPage ->
                         LinkPreview(
                             webPage = webPage,
@@ -166,33 +227,12 @@ fun TextMessageBubble(
                     }
                 }
 
-                Row(
-                    modifier = Modifier.align(Alignment.End),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    if (msg.editDate > 0) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = stringResource(R.string.info_edited),
-                            modifier = Modifier.size(14.dp),
-                            tint = timeColor
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                    }
-                    Text(
-                        text = formatTime(msg.date, timeFormat),
-                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
-                        color = timeColor
-                    )
-
-                    if (isOutgoing) {
-                        Spacer(modifier = Modifier.width(4.dp))
-                        MessageSendingStatusIcon(
-                            sendingState = msg.sendingState,
-                            isRead = msg.isRead,
-                            baseColor = timeColor,
-                            size = 14.dp
-                        )
+                if (!useInlineTimestamp) {
+                    Row(
+                        modifier = Modifier.align(Alignment.End),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        timestampRow()
                     }
                 }
             }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/TextWithTimestampLayout.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/message/TextWithTimestampLayout.kt
@@ -1,0 +1,58 @@
+package org.monogram.presentation.features.chats.conversation.ui.message
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+
+@Composable
+internal fun TextWithTimestampLayout(
+    modifier: Modifier = Modifier,
+    horizontalPadding: Int = 8,
+    textContent: @Composable () -> Unit,
+    timestampContent: @Composable () -> Unit
+) {
+    Layout(
+        contents = listOf(textContent, timestampContent),
+        modifier = modifier
+    ) { (textMeasurables, timestampMeasurables), constraints ->
+        val horizontalPaddingPx = horizontalPadding.dp.roundToPx()
+
+        val timestampPlaceable = timestampMeasurables.first().measure(Constraints())
+        val timestampWidth = timestampPlaceable.width
+        val timestampHeight = timestampPlaceable.height
+
+        val textPlaceable = textMeasurables.first().measure(constraints.copy(minWidth = 0))
+        val textWidth = textPlaceable.width
+        val textHeight = textPlaceable.height
+
+        val totalInlineWidth = textWidth + horizontalPaddingPx + timestampWidth
+        val fitsInline = totalInlineWidth <= constraints.maxWidth
+
+        if (fitsInline) {
+            val layoutWidth = max(totalInlineWidth, textWidth)
+            val layoutHeight = max(textHeight, timestampHeight)
+
+            layout(layoutWidth, layoutHeight) {
+                textPlaceable.placeRelative(0, 0)
+                timestampPlaceable.placeRelative(
+                    x = layoutWidth - timestampWidth,
+                    y = layoutHeight - timestampHeight
+                )
+            }
+        } else {
+            val layoutWidth = max(textWidth, timestampWidth)
+            val layoutHeight = textHeight + timestampHeight
+
+            layout(layoutWidth, layoutHeight) {
+                textPlaceable.placeRelative(0, 0)
+                timestampPlaceable.placeRelative(
+                    x = layoutWidth - timestampWidth,
+                    y = textHeight
+                )
+            }
+        }
+    }
+}

--- a/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
+++ b/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
@@ -27,5 +27,5 @@ class FolderChatsNormalizationTest {
     }
 
     private fun chat(id: Long, order: Long = id): ChatModel =
-        ChatModel(id = id, title = "chat $id", order = order)
+        ChatModel(id = id, title = "chat $id", order = order, unreadCount = 0)
 }


### PR DESCRIPTION
Fixed #262 
- Swapped out the basic Column for a custom layout that measures text width
- Now tucks the timestamp inline if it fits on the last line
- Big emoji and link previews still get their own line