### PR TITLE
Fix deleted accounts showing up without names (#251)

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentTopBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentTopBar.kt
@@ -321,11 +321,12 @@ fun ChatContentTopBar(
                 }
 
                 val threadTitle = stringResource(R.string.thread_title)
-                val title = remember(currentTopic, topBarState.rootMessage, topBarState.chatTitle, threadTitle) {
+                val deletedAccountTitle = stringResource(R.string.deleted_account)
+                val title = remember(currentTopic, topBarState.rootMessage, topBarState.chatTitle, threadTitle, deletedAccountTitle) {
                     when {
                         currentTopic != null -> currentTopic.name
                         topBarState.rootMessage != null -> threadTitle
-                        else -> topBarState.chatTitle
+                        else -> topBarState.chatTitle.ifBlank { deletedAccountTitle }
                     }
                 }
                 val topicEmojiPath = currentTopic?.iconCustomEmojiPath

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/list/components/ChatListItem.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/list/components/ChatListItem.kt
@@ -229,6 +229,7 @@ private fun ChatListItemHeader(
     val timeFormat = dateFormatManager.getHourMinuteFormat()
     val chatTime = chat.lastMessageDate.toDate().toShortRelativeDate(timeFormat)
     val savedMessagesTitle = stringResource(R.string.menu_saved_messages)
+    val deletedAccountTitle = stringResource(R.string.deleted_account)
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -246,14 +247,14 @@ private fun ChatListItemHeader(
                 Spacer(Modifier.width(4.dp))
             }
             Text(
-                text = if (isSavedMessages) savedMessagesTitle else chat.title,
+                text = if (isSavedMessages) savedMessagesTitle else chat.title.ifBlank { deletedAccountTitle },
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.semantics {
-                    contentDescription = if (isSavedMessages) savedMessagesTitle else chat.title
+                    contentDescription = if (isSavedMessages) savedMessagesTitle else chat.title.ifBlank { deletedAccountTitle }
                 }
             )
 

--- a/presentation/src/main/java/org/monogram/presentation/features/profile/ProfileContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/profile/ProfileContent.kt
@@ -122,10 +122,15 @@ fun ProfileContent(component: ProfileComponent) {
 
 
     val unknownTitle = stringResource(R.string.unknown_title)
-    val title = remember(user, chat, unknownTitle) {
-        chat?.title ?: listOfNotNull(user?.firstName, user?.lastName)
-            .joinToString(" ")
-            .ifBlank { unknownTitle }
+    val deletedAccountTitle = stringResource(R.string.deleted_account)
+    val title = remember(user, chat, unknownTitle, deletedAccountTitle) {
+        if (user?.type == UserTypeEnum.DELETED) {
+            deletedAccountTitle
+        } else {
+            chat?.title?.takeIf { it.isNotBlank() } ?: listOfNotNull(user?.firstName, user?.lastName)
+                .joinToString(" ")
+                .ifBlank { unknownTitle }
+        }
     }
 
     val membersOnlineCountFormat = stringResource(R.string.members_online_count_format)

--- a/presentation/src/main/res/values/string.xml
+++ b/presentation/src/main/res/values/string.xml
@@ -2456,4 +2456,5 @@
     <string name="auth_password_hash_invalid">Invalid password</string>
     <string name="unexpected_error">An unexpected error occurred</string>
     <string name="unread_messages">%1$d unread messages</string>
+    <string name="deleted_account">Deleted Account</string>
 </resources>

--- a/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
+++ b/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
@@ -27,5 +27,5 @@ class FolderChatsNormalizationTest {
     }
 
     private fun chat(id: Long, order: Long = id): ChatModel =
-        ChatModel(id = id, title = "chat $id", order = order)
+        ChatModel(id = id, title = "chat $id", order = order, unreadCount = 0)
 }


### PR DESCRIPTION
Fixed #251
### Problem
When a Telegram user deletes their account, their first/last name and chat title become empty strings. This caused blank names to appear across the app  in the chat list, conversation top bar, and profile screen.
### Changes
- Added a `deleted_account` string resource.
- Updated the Chat List, Profile Screen, and Conversation Top Bar to display "Deleted Account" instead of showing a blank name when a user deletes their account.
- Avatar fallback now correctly shows the letter "D" for these accounts.