### PR TITLE
Fix Edit Profile not updating UI

### DIFF
--- a/data/src/main/java/org/monogram/data/repository/user/UserRepositoryImpl.kt
+++ b/data/src/main/java/org/monogram/data/repository/user/UserRepositoryImpl.kt
@@ -194,6 +194,15 @@ class UserRepositoryImpl(
             fullInfoRequests.remove(userId)
         }
     }
+    
+    override suspend fun refreshUserFullInfo(userId: Long) {
+        if (userId <= 0) return
+        val fullInfo = remote.getUserFullInfo(userId) ?: return
+        cacheUserFullInfo(userId, fullInfo)
+        userLocal.saveFullInfoEntity(fullInfo.toEntity(userId))
+        syncUserPersonalAvatarPath(userId, fullInfo)
+        handleUserIdUpdated(userId)
+    }
 
     override suspend fun resolveUserChatFullInfo(userId: Long): ChatFullInfoModel? {
         if (userId <= 0L) return null

--- a/domain/src/main/java/org/monogram/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/org/monogram/domain/repository/UserRepository.kt
@@ -12,6 +12,7 @@ interface UserRepository {
     suspend fun getMe(): UserModel
     suspend fun getUser(userId: Long): UserModel?
     suspend fun getUserFullInfo(userId: Long): UserModel?
+    suspend fun refreshUserFullInfo(userId: Long)
     suspend fun resolveUserChatFullInfo(userId: Long): ChatFullInfoModel?
     fun getUserFlow(userId: Long): Flow<UserModel?>
 

--- a/presentation/src/main/java/org/monogram/presentation/settings/profile/DefaultEditProfileComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/profile/DefaultEditProfileComponent.kt
@@ -218,6 +218,7 @@ class DefaultEditProfileComponent(
                     userProfileEditRepository.setBusinessOpeningHours(currentState.businessOpeningHours)
                 }
 
+                userRepository.refreshUserFullInfo(user.id)
                 onBack()
             } catch (e: Exception) {
                 _state.update { it.copy(isLoading = false, error = e.message) }

--- a/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
+++ b/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
@@ -27,5 +27,5 @@ class FolderChatsNormalizationTest {
     }
 
     private fun chat(id: Long, order: Long = id): ChatModel =
-        ChatModel(id = id, title = "chat $id", order = order)
+        ChatModel(id = id, title = "chat $id", order = order, unreadCount = 0)
 }


### PR DESCRIPTION
Fixes #275

**Description:**
Resolved an issue where changing profile details (like Bio) on the "Edit Profile" screen did not visually persist after saving. The app successfully sent the update to the server but failed to invalidate the local cache for `UserFullInfo`.

**Changes:**
- Added a `refreshUserFullInfo` method to `UserRepository` to force fetch the updated user information.
- Called this refresh method right before exiting the Edit Profile screen. This ensures the local database and UI flow reflect the latest changes immediately instead of showing the old cached profile data.
