### PR TITLE
feat: Add option to always open links in external browser (#268)

### DIFF
--- a/domain/src/main/java/org/monogram/domain/repository/AppPreferencesProvider.kt
+++ b/domain/src/main/java/org/monogram/domain/repository/AppPreferencesProvider.kt
@@ -109,6 +109,9 @@ interface AppPreferencesProvider {
     val isPermissionRequested: StateFlow<Boolean>
     val isSupportViewed: StateFlow<Boolean>
 
+    val inAppBrowserEnabled: StateFlow<Boolean>
+    fun setInAppBrowserEnabled(enabled: Boolean)
+
     fun setAutoDownloadMobile(enabled: Boolean)
     fun setAutoDownloadWifi(enabled: Boolean)
     fun setAutoDownloadRoaming(enabled: Boolean)

--- a/presentation/src/main/java/org/monogram/presentation/core/util/AppPreferences.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/util/AppPreferences.kt
@@ -316,6 +316,9 @@ class AppPreferences(
     private val _isDragToBackEnabled = MutableStateFlow(prefs.getBoolean(KEY_DRAG_TO_BACK, true))
     val isDragToBackEnabled: StateFlow<Boolean> = _isDragToBackEnabled
 
+    private val _inAppBrowserEnabled = MutableStateFlow(prefs.getBoolean(KEY_IN_APP_BROWSER, true))
+    override val inAppBrowserEnabled: StateFlow<Boolean> = _inAppBrowserEnabled
+
     private val _isChatAnimationsEnabled = MutableStateFlow(prefs.getBoolean(KEY_CHAT_ANIMATIONS_ENABLED, true))
     override val isChatAnimationsEnabled: StateFlow<Boolean> = _isChatAnimationsEnabled
 
@@ -951,6 +954,11 @@ class AppPreferences(
         _isDragToBackEnabled.value = enabled
     }
 
+    override fun setInAppBrowserEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_IN_APP_BROWSER, enabled).apply()
+        _inAppBrowserEnabled.value = enabled
+    }
+
     override fun setChatAnimationsEnabled(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_CHAT_ANIMATIONS_ENABLED, enabled).apply()
         _isChatAnimationsEnabled.value = enabled
@@ -1306,6 +1314,7 @@ class AppPreferences(
         private const val KEY_IS_ARCHIVE_ALWAYS_VISIBLE = "is_archive_always_visible"
         private const val KEY_SHOW_LINK_PREVIEWS = "show_link_previews"
         private const val KEY_DRAG_TO_BACK = "drag_to_back"
+        private const val KEY_IN_APP_BROWSER = "in_app_browser"
         private const val KEY_CHAT_ANIMATIONS_ENABLED = "chat_animations_enabled"
         private const val KEY_CHAT_LIST_MESSAGE_LINES = "chat_list_message_lines"
         private const val KEY_SHOW_CHAT_LIST_PHOTOS = "show_chat_list_photos"

--- a/presentation/src/main/java/org/monogram/presentation/root/DefaultRootComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/root/DefaultRootComponent.kt
@@ -470,6 +470,10 @@ class DefaultRootComponent(
 
     private fun openBrowser(url: String) {
         if (!url.startsWith("http")) return
+        if (!appPreferences.inAppBrowserEnabled.value) {
+            externalNavigator.openUrl(url)
+            return
+        }
         navigation.navigate { stack ->
             val newStack = stack.filterNot { it is Config.WebView && it.url == url }
             newStack + Config.WebView(url)

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
@@ -83,6 +83,7 @@ interface ChatSettingsComponent {
     fun onNightModeEndTimeChanged(time: String)
     fun onNightModeBrightnessThresholdChanged(threshold: Float)
     fun onDragToBackChanged(enabled: Boolean)
+    fun onInAppBrowserEnabledChanged(enabled: Boolean)
     fun onTabletInterfaceEnabledChanged(enabled: Boolean)
     fun onAdBlockClick()
     fun onEmojiStyleChanged(style: EmojiStyle)
@@ -143,6 +144,7 @@ interface ChatSettingsComponent {
         val nightModeEndTime: String = "07:00",
         val nightModeBrightnessThreshold: Float = 0.2f,
         val isDragToBackEnabled: Boolean = true,
+        val inAppBrowserEnabled: Boolean = true,
         val isTabletInterfaceEnabled: Boolean = true,
         val emojiStyle: EmojiStyle = EmojiStyle.SYSTEM,
         val isAppleEmojiDownloaded: Boolean = false,
@@ -225,6 +227,7 @@ class DefaultChatSettingsComponent(
             nightModeEndTime = appPreferences.nightModeEndTime.value,
             nightModeBrightnessThreshold = appPreferences.nightModeBrightnessThreshold.value,
             isDragToBackEnabled = appPreferences.isDragToBackEnabled.value,
+            inAppBrowserEnabled = appPreferences.inAppBrowserEnabled.value,
             isTabletInterfaceEnabled = appPreferences.isTabletInterfaceEnabled.value,
             emojiStyle = appPreferences.emojiStyle.value,
             isAppleEmojiDownloaded = appPreferences.isAppleEmojiDownloaded.value,
@@ -510,6 +513,12 @@ class DefaultChatSettingsComponent(
         appPreferences.isDragToBackEnabled
             .onEach { enabled ->
                 _state.update { it.copy(isDragToBackEnabled = enabled) }
+            }
+            .launchIn(scope)
+
+        appPreferences.inAppBrowserEnabled
+            .onEach { enabled ->
+                _state.update { it.copy(inAppBrowserEnabled = enabled) }
             }
             .launchIn(scope)
 
@@ -1008,6 +1017,10 @@ class DefaultChatSettingsComponent(
 
     override fun onDragToBackChanged(enabled: Boolean) {
         appPreferences.setDragToBackEnabled(enabled)
+    }
+
+    override fun onInAppBrowserEnabledChanged(enabled: Boolean) {
+        appPreferences.setInAppBrowserEnabled(enabled)
     }
 
     override fun onTabletInterfaceEnabledChanged(enabled: Boolean) {

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.Archive
 import androidx.compose.material.icons.rounded.Block
 import androidx.compose.material.icons.rounded.Brightness4
+import androidx.compose.material.icons.rounded.OpenInBrowser
 import androidx.compose.material.icons.rounded.BrightnessAuto
 import androidx.compose.material.icons.rounded.BrightnessLow
 import androidx.compose.material.icons.rounded.Check

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
@@ -941,8 +941,17 @@ fun ChatSettingsContent(component: ChatSettingsComponent) {
                     subtitle = stringResource(R.string.drag_to_back_subtitle),
                     checked = state.isDragToBackEnabled,
                     iconColor = tealColor,
-                    position = ItemPosition.BOTTOM,
+                    position = ItemPosition.MIDDLE,
                     onCheckedChange = component::onDragToBackChanged
+                )
+                SettingsSwitchTile(
+                    icon = Icons.Rounded.OpenInBrowser,
+                    title = stringResource(R.string.in_app_browser_title),
+                    subtitle = stringResource(R.string.in_app_browser_subtitle),
+                    checked = state.inAppBrowserEnabled,
+                    iconColor = purpleColor,
+                    position = ItemPosition.BOTTOM,
+                    onCheckedChange = component::onInAppBrowserEnabledChanged
                 )
             }
 

--- a/presentation/src/main/res/values/string.xml
+++ b/presentation/src/main/res/values/string.xml
@@ -923,6 +923,8 @@
     <!-- Chat Settings -->
     <string name="chat_settings_header">Chat Settings</string>
     <string name="appearance_header">Appearance</string>
+    <string name="in_app_browser_title">In-App Browser</string>
+    <string name="in_app_browser_subtitle">Open external links inside the app</string>
     <string name="message_text_size_title">Message text size</string>
     <string name="message_letter_spacing_title">Message letter spacing</string>
     <string name="bubble_rounding_title">Bubble rounding</string>

--- a/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
+++ b/presentation/src/test/java/org/monogram/presentation/features/chats/list/FolderChatsNormalizationTest.kt
@@ -27,5 +27,5 @@ class FolderChatsNormalizationTest {
     }
 
     private fun chat(id: Long, order: Long = id): ChatModel =
-        ChatModel(id = id, title = "chat $id", order = order)
+        ChatModel(id = id, title = "chat $id", order = order, unreadCount = 0)
 }


### PR DESCRIPTION
#268 

This introduces a new "In-App Browser" toggle under Chat Settings -> Appearance, giving users the flexibility to bypass the internal web viewer. By default it's enabled, but when toggled off, `DefaultRootComponent.openBrowser()` now catches the preference state and securely hands off the URL routing directly to the system's default external browser via `externalNavigator.openUrl()`.