### PR TITLE
feat: auto-open keyboard when search is activated in chat list (#265)

### DIFF
--- a/presentation/src/main/java/org/monogram/presentation/features/chats/list/components/ChatListTopBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/list/components/ChatListTopBar.kt
@@ -131,7 +131,13 @@ fun ChatListTopBar(
                             onExpandedChange = {},
                             placeholder = { Text(stringResource(R.string.search_conversations_placeholder)) },
                             leadingIcon = {
-                                IconButton(onClick = onSearchToggle, shapes = iconButtonShapes) {
+                                IconButton(
+                                    onClick = {
+                                        keyboardController?.hide()
+                                        onSearchToggle()
+                                    },
+                                    shapes = iconButtonShapes
+                                ) {
                                     Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = stringResource(R.string.cd_back))
                                 }
                             },

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/list/components/ChatListTopBar.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/list/components/ChatListTopBar.kt
@@ -63,7 +63,10 @@ import org.monogram.presentation.R
 import org.monogram.presentation.core.ui.ExpressiveDefaults
 import org.monogram.presentation.core.util.LocalTabletInterfaceEnabled
 import org.monogram.presentation.features.stickers.ui.view.StickerImage
-
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -102,6 +105,14 @@ fun ChatListTopBar(
         label = "TopBarSearchTransition"
     ) { active ->
         if (active) {
+            val focusRequester = remember { FocusRequester() }
+            val keyboardController = LocalSoftwareKeyboardController.current
+
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+                keyboardController?.show()
+            }
+
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -112,6 +123,7 @@ fun ChatListTopBar(
                 SearchBar(
                     inputField = {
                         SearchBarDefaults.InputField(
+                            modifier = Modifier.focusRequester(focusRequester),
                             query = searchQuery,
                             onQueryChange = onSearchQueryChange,
                             onSearch = {},


### PR DESCRIPTION
Fixes #265 

Added a `FocusRequester` to the search bar in `ChatListTopBar`. Now when you tap the search icon, it automatically focuses the input and pops up the keyboard. Saves an extra tap and feels much smoother.
