### PR TITLE
Added option to hide message reactions

### DIFF
--- a/data/src/test/java/org/monogram/data/infra/ConnectionManagerTest.kt
+++ b/data/src/test/java/org/monogram/data/infra/ConnectionManagerTest.kt
@@ -521,6 +521,7 @@ class ConnectionManagerTest {
         override val isChatAnimationsEnabled = MutableStateFlow(false)
         override val chatListMessageLines = MutableStateFlow(2)
         override val showChatListPhotos = MutableStateFlow(true)
+        override val showReactions = MutableStateFlow(true)
         override val privateChatsNotifications = MutableStateFlow(true)
         override val groupsNotifications = MutableStateFlow(true)
         override val channelsNotifications = MutableStateFlow(true)
@@ -677,6 +678,10 @@ class ConnectionManagerTest {
 
         override fun setShowChatListPhotos(enabled: Boolean) {
             showChatListPhotos.value = enabled
+        }
+
+        override fun setShowReactions(enabled: Boolean) {
+            showReactions.value = enabled
         }
 
         override fun setPrivateChatsNotifications(enabled: Boolean) {

--- a/domain/src/main/java/org/monogram/domain/repository/AppPreferencesProvider.kt
+++ b/domain/src/main/java/org/monogram/domain/repository/AppPreferencesProvider.kt
@@ -71,7 +71,6 @@ interface AppPreferencesProvider {
     val isChatAnimationsEnabled: StateFlow<Boolean>
     val chatListMessageLines: StateFlow<Int>
     val showChatListPhotos: StateFlow<Boolean>
-    val messageOptionsOnSingleTapEnabled: StateFlow<Boolean>
     val showReactions: StateFlow<Boolean>
 
     val privateChatsNotifications: StateFlow<Boolean>
@@ -128,7 +127,6 @@ interface AppPreferencesProvider {
     fun setChatAnimationsEnabled(enabled: Boolean)
     fun setChatListMessageLines(lines: Int)
     fun setShowChatListPhotos(enabled: Boolean)
-    fun setMessageOptionsOnSingleTapEnabled(enabled: Boolean)
     fun setShowReactions(enabled: Boolean)
 
     fun setPrivateChatsNotifications(enabled: Boolean)

--- a/domain/src/main/java/org/monogram/domain/repository/AppPreferencesProvider.kt
+++ b/domain/src/main/java/org/monogram/domain/repository/AppPreferencesProvider.kt
@@ -71,6 +71,8 @@ interface AppPreferencesProvider {
     val isChatAnimationsEnabled: StateFlow<Boolean>
     val chatListMessageLines: StateFlow<Int>
     val showChatListPhotos: StateFlow<Boolean>
+    val messageOptionsOnSingleTapEnabled: StateFlow<Boolean>
+    val showReactions: StateFlow<Boolean>
 
     val privateChatsNotifications: StateFlow<Boolean>
     val groupsNotifications: StateFlow<Boolean>
@@ -126,6 +128,8 @@ interface AppPreferencesProvider {
     fun setChatAnimationsEnabled(enabled: Boolean)
     fun setChatListMessageLines(lines: Int)
     fun setShowChatListPhotos(enabled: Boolean)
+    fun setMessageOptionsOnSingleTapEnabled(enabled: Boolean)
+    fun setShowReactions(enabled: Boolean)
 
     fun setPrivateChatsNotifications(enabled: Boolean)
     fun setGroupsNotifications(enabled: Boolean)

--- a/presentation/src/main/java/org/monogram/presentation/core/util/AppPreferences.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/util/AppPreferences.kt
@@ -331,6 +331,12 @@ class AppPreferences(
     private val _showChatListPhotos = MutableStateFlow(prefs.getBoolean(KEY_SHOW_CHAT_LIST_PHOTOS, true))
     override val showChatListPhotos: StateFlow<Boolean> = _showChatListPhotos
 
+    private val _messageOptionsOnSingleTapEnabled = MutableStateFlow(prefs.getBoolean(KEY_MESSAGE_OPTIONS_SINGLE_TAP_ENABLED, true))
+    override val messageOptionsOnSingleTapEnabled: StateFlow<Boolean> = _messageOptionsOnSingleTapEnabled
+
+    private val _showReactions = MutableStateFlow(prefs.getBoolean(KEY_SHOW_REACTIONS, true))
+    override val showReactions: StateFlow<Boolean> = _showReactions
+
     private val _showAllChatsFolder =
         MutableStateFlow(prefs.getBoolean(KEY_SHOW_ALL_CHATS_FOLDER, true))
     val showAllChatsFolder: StateFlow<Boolean> = _showAllChatsFolder
@@ -982,6 +988,16 @@ class AppPreferences(
         _showChatListPhotos.value = enabled
     }
 
+    override fun setMessageOptionsOnSingleTapEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_MESSAGE_OPTIONS_SINGLE_TAP_ENABLED, enabled).apply()
+        _messageOptionsOnSingleTapEnabled.value = enabled
+    }
+
+    override fun setShowReactions(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_SHOW_REACTIONS, enabled).apply()
+        _showReactions.value = enabled
+    }
+
     fun setShowAllChatsFolder(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_SHOW_ALL_CHATS_FOLDER, enabled).apply()
         _showAllChatsFolder.value = enabled
@@ -1328,6 +1344,8 @@ class AppPreferences(
         private const val KEY_CHAT_ANIMATIONS_ENABLED = "chat_animations_enabled"
         private const val KEY_CHAT_LIST_MESSAGE_LINES = "chat_list_message_lines"
         private const val KEY_SHOW_CHAT_LIST_PHOTOS = "show_chat_list_photos"
+        private const val KEY_MESSAGE_OPTIONS_SINGLE_TAP_ENABLED = "message_options_single_tap_enabled"
+        private const val KEY_SHOW_REACTIONS = "show_reactions"
         private const val KEY_SHOW_ALL_CHATS_FOLDER = "show_all_chats_folder"
         private const val KEY_TABLET_INTERFACE_ENABLED = "tablet_interface_enabled"
 

--- a/presentation/src/main/java/org/monogram/presentation/core/util/AppPreferences.kt
+++ b/presentation/src/main/java/org/monogram/presentation/core/util/AppPreferences.kt
@@ -331,9 +331,6 @@ class AppPreferences(
     private val _showChatListPhotos = MutableStateFlow(prefs.getBoolean(KEY_SHOW_CHAT_LIST_PHOTOS, true))
     override val showChatListPhotos: StateFlow<Boolean> = _showChatListPhotos
 
-    private val _messageOptionsOnSingleTapEnabled = MutableStateFlow(prefs.getBoolean(KEY_MESSAGE_OPTIONS_SINGLE_TAP_ENABLED, true))
-    override val messageOptionsOnSingleTapEnabled: StateFlow<Boolean> = _messageOptionsOnSingleTapEnabled
-
     private val _showReactions = MutableStateFlow(prefs.getBoolean(KEY_SHOW_REACTIONS, true))
     override val showReactions: StateFlow<Boolean> = _showReactions
 
@@ -988,11 +985,6 @@ class AppPreferences(
         _showChatListPhotos.value = enabled
     }
 
-    override fun setMessageOptionsOnSingleTapEnabled(enabled: Boolean) {
-        prefs.edit().putBoolean(KEY_MESSAGE_OPTIONS_SINGLE_TAP_ENABLED, enabled).apply()
-        _messageOptionsOnSingleTapEnabled.value = enabled
-    }
-
     override fun setShowReactions(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_SHOW_REACTIONS, enabled).apply()
         _showReactions.value = enabled
@@ -1344,7 +1336,6 @@ class AppPreferences(
         private const val KEY_CHAT_ANIMATIONS_ENABLED = "chat_animations_enabled"
         private const val KEY_CHAT_LIST_MESSAGE_LINES = "chat_list_message_lines"
         private const val KEY_SHOW_CHAT_LIST_PHOTOS = "show_chat_list_photos"
-        private const val KEY_MESSAGE_OPTIONS_SINGLE_TAP_ENABLED = "message_options_single_tap_enabled"
         private const val KEY_SHOW_REACTIONS = "show_reactions"
         private const val KEY_SHOW_ALL_CHATS_FOLDER = "show_all_chats_folder"
         private const val KEY_TABLET_INTERFACE_ENABLED = "tablet_interface_enabled"

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ChatComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ChatComponent.kt
@@ -311,6 +311,8 @@ interface ChatComponent {
         val autoplayVideos: Boolean = true,
         val showLinkPreviews: Boolean = true,
         val fixLinkPreviews: Boolean = true,
+        val messageOptionsOnSingleTapEnabled: Boolean = true,
+        val showReactions: Boolean = true,
         val isChatAnimationsEnabled: Boolean = true,
         val selectedMessageIds: Set<Long> = emptySet(),
         val selectedStickerSet: StickerSetModel? = null,

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ChatComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ChatComponent.kt
@@ -311,7 +311,6 @@ interface ChatComponent {
         val autoplayVideos: Boolean = true,
         val showLinkPreviews: Boolean = true,
         val fixLinkPreviews: Boolean = true,
-        val messageOptionsOnSingleTapEnabled: Boolean = true,
         val showReactions: Boolean = true,
         val isChatAnimationsEnabled: Boolean = true,
         val selectedMessageIds: Set<Long> = emptySet(),

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/logic/preferences/Preferences.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/logic/preferences/Preferences.kt
@@ -138,6 +138,14 @@ internal fun DefaultChatComponent.observePreferences(availableWallpapers: List<W
         _state.update { it.copy(fixLinkPreviews = value) }
     }.launchIn(scope)
 
+    appPreferences.messageOptionsOnSingleTapEnabled.onEach { value ->
+        _state.update { it.copy(messageOptionsOnSingleTapEnabled = value) }
+    }.launchIn(scope)
+
+    appPreferences.showReactions.onEach { value ->
+        _state.update { it.copy(showReactions = value) }
+    }.launchIn(scope)
+
     combine(appPreferences.isChatAnimationsEnabled, appPreferences.isPowerSavingMode) { enabled, powerSaving ->
         if (powerSaving) false else enabled
     }.onEach { value ->

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/logic/preferences/Preferences.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/logic/preferences/Preferences.kt
@@ -138,9 +138,7 @@ internal fun DefaultChatComponent.observePreferences(availableWallpapers: List<W
         _state.update { it.copy(fixLinkPreviews = value) }
     }.launchIn(scope)
 
-    appPreferences.messageOptionsOnSingleTapEnabled.onEach { value ->
-        _state.update { it.copy(messageOptionsOnSingleTapEnabled = value) }
-    }.launchIn(scope)
+
 
     appPreferences.showReactions.onEach { value ->
         _state.update { it.copy(showReactions = value) }

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/AlbumMessageBubbleContainer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/AlbumMessageBubbleContainer.kt
@@ -72,10 +72,11 @@ internal fun AlbumMessageBubbleContainer(
 ) {
     if (messages.isEmpty()) return
 
-    val orderedMessages = remember(messages) {
-        messages
+    val orderedMessages = remember(messages, appearance.showReactions) {
+        val sorted = messages
             .distinctBy { it.id }
             .sortedWith(compareBy<MessageModel> { it.date }.thenBy { it.id })
+        if (appearance.showReactions) sorted else sorted.map { it.copy(reactions = emptyList()) }
     }
 
     val firstMsg = orderedMessages.first()

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/MessageBubbleContainer.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/MessageBubbleContainer.kt
@@ -450,15 +450,19 @@ private fun MessageContentSelector(
     downloadUtils: IDownloadUtils,
     isAnyViewerOpen: Boolean = false
 ) {
+    val finalMsg = remember(msg, appearance.showReactions) {
+        if (appearance.showReactions) msg else msg.copy(reactions = emptyList())
+    }
+
     Column(
         modifier = Modifier.width(IntrinsicSize.Max),
         horizontalAlignment = if (isOutgoing) Alignment.End else Alignment.Start
     ) {
-        when (val content = msg.content) {
+        when (val content = finalMsg.content) {
             is MessageContent.Text -> {
                 TextMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -481,7 +485,7 @@ private fun MessageContentSelector(
             is MessageContent.Sticker -> {
                 StickerMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     stickerSize = appearance.stickerSize,
                     onReplyClick = onGoToReply,
@@ -494,7 +498,7 @@ private fun MessageContentSelector(
             is MessageContent.Photo -> {
                 PhotoMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -520,7 +524,7 @@ private fun MessageContentSelector(
             is MessageContent.Video -> {
                 VideoMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -546,7 +550,7 @@ private fun MessageContentSelector(
             is MessageContent.VideoNote -> {
                 VideoNoteBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     onVideoClick = onVideoClick,
                     onCancelDownload = onCancelDownload,
@@ -559,7 +563,7 @@ private fun MessageContentSelector(
             is MessageContent.Voice -> {
                 VoiceMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -584,7 +588,7 @@ private fun MessageContentSelector(
             is MessageContent.Gif -> {
                 GifMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -609,7 +613,7 @@ private fun MessageContentSelector(
             is MessageContent.Document -> {
                 DocumentMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -633,7 +637,7 @@ private fun MessageContentSelector(
             is MessageContent.Audio -> {
                 AudioMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -656,7 +660,7 @@ private fun MessageContentSelector(
             is MessageContent.Contact -> {
                 ContactMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -677,7 +681,7 @@ private fun MessageContentSelector(
             is MessageContent.Poll -> {
                 PollMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -699,7 +703,7 @@ private fun MessageContentSelector(
             is MessageContent.Location -> {
                 LocationMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,
@@ -719,7 +723,7 @@ private fun MessageContentSelector(
             is MessageContent.Venue -> {
                 VenueMessageBubble(
                     content = content,
-                    msg = msg,
+                    msg = finalMsg,
                     isOutgoing = isOutgoing,
                     isSameSenderAbove = senderGrouping.isSameSenderAbove,
                     isSameSenderBelow = senderGrouping.isSameSenderBelow,

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/MessageRowContracts.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/MessageRowContracts.kt
@@ -16,7 +16,9 @@ internal data class MessageAppearanceConfig(
     val autoDownloadMobile: Boolean = false,
     val autoDownloadWifi: Boolean = false,
     val autoDownloadRoaming: Boolean = false,
-    val autoDownloadFiles: Boolean = false
+    val autoDownloadFiles: Boolean = false,
+    val messageOptionsOnSingleTapEnabled: Boolean = true,
+    val showReactions: Boolean = true
 )
 
 @Immutable

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/MessageRowContracts.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/MessageRowContracts.kt
@@ -17,7 +17,6 @@ internal data class MessageAppearanceConfig(
     val autoDownloadWifi: Boolean = false,
     val autoDownloadRoaming: Boolean = false,
     val autoDownloadFiles: Boolean = false,
-    val messageOptionsOnSingleTapEnabled: Boolean = true,
     val showReactions: Boolean = true
 )
 

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentDerivedState.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentDerivedState.kt
@@ -244,7 +244,6 @@ internal fun rememberChatMessageListState(
         state.autoplayGifs,
         state.autoplayVideos,
         state.showLinkPreviews,
-        state.messageOptionsOnSingleTapEnabled,
         state.showReactions,
         state.isChatAnimationsEnabled,
         showInitialLoading,
@@ -283,7 +282,6 @@ internal fun rememberChatMessageListState(
             autoplayGifs = state.viewportPhase == ChatViewportPhase.Settled && state.autoplayGifs,
             autoplayVideos = state.viewportPhase == ChatViewportPhase.Settled && state.autoplayVideos,
             showLinkPreviews = state.showLinkPreviews,
-            messageOptionsOnSingleTapEnabled = state.messageOptionsOnSingleTapEnabled,
             showReactions = state.showReactions,
             isChatAnimationsEnabled = state.isChatAnimationsEnabled,
             suppressEntryAnimations = shouldSuppressMessageEntryAnimations(

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentDerivedState.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentDerivedState.kt
@@ -244,6 +244,8 @@ internal fun rememberChatMessageListState(
         state.autoplayGifs,
         state.autoplayVideos,
         state.showLinkPreviews,
+        state.messageOptionsOnSingleTapEnabled,
+        state.showReactions,
         state.isChatAnimationsEnabled,
         showInitialLoading,
         state.viewportPhase
@@ -281,6 +283,8 @@ internal fun rememberChatMessageListState(
             autoplayGifs = state.viewportPhase == ChatViewportPhase.Settled && state.autoplayGifs,
             autoplayVideos = state.viewportPhase == ChatViewportPhase.Settled && state.autoplayVideos,
             showLinkPreviews = state.showLinkPreviews,
+            messageOptionsOnSingleTapEnabled = state.messageOptionsOnSingleTapEnabled,
+            showReactions = state.showReactions,
             isChatAnimationsEnabled = state.isChatAnimationsEnabled,
             suppressEntryAnimations = shouldSuppressMessageEntryAnimations(
                 showInitialLoading = showInitialLoading,

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentList.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentList.kt
@@ -149,6 +149,7 @@ data class ChatMessageListUiState(
     val autoplayGifs: Boolean,
     val autoplayVideos: Boolean,
     val showLinkPreviews: Boolean,
+    val messageOptionsOnSingleTapEnabled: Boolean,
     val isChatAnimationsEnabled: Boolean,
     val suppressEntryAnimations: Boolean,
     val isViewportSettled: Boolean
@@ -1415,7 +1416,9 @@ private fun ChatMessageListUiState.toAppearanceConfig(): MessageAppearanceConfig
         autoDownloadMobile = autoDownloadMobile,
         autoDownloadWifi = autoDownloadWifi,
         autoDownloadRoaming = autoDownloadRoaming,
-        autoDownloadFiles = autoDownloadFiles
+        autoDownloadFiles = autoDownloadFiles,
+        messageOptionsOnSingleTapEnabled = messageOptionsOnSingleTapEnabled,
+        showReactions = showReactions
     )
 
 private fun ChatMessageListUiState.toBehaviorConfig(

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentList.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatContentList.kt
@@ -149,7 +149,7 @@ data class ChatMessageListUiState(
     val autoplayGifs: Boolean,
     val autoplayVideos: Boolean,
     val showLinkPreviews: Boolean,
-    val messageOptionsOnSingleTapEnabled: Boolean,
+    val showReactions: Boolean,
     val isChatAnimationsEnabled: Boolean,
     val suppressEntryAnimations: Boolean,
     val isViewportSettled: Boolean
@@ -1417,7 +1417,6 @@ private fun ChatMessageListUiState.toAppearanceConfig(): MessageAppearanceConfig
         autoDownloadWifi = autoDownloadWifi,
         autoDownloadRoaming = autoDownloadRoaming,
         autoDownloadFiles = autoDownloadFiles,
-        messageOptionsOnSingleTapEnabled = messageOptionsOnSingleTapEnabled,
         showReactions = showReactions
     )
 

--- a/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatMessageOptionsMenu.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/chats/conversation/ui/content/ChatMessageOptionsMenu.kt
@@ -284,6 +284,7 @@ fun ChatMessageOptionsMenu(
     }
     MessageOptionsMenu(
         message = menuMessage.copy(readDate = messageWithReadDate.readDate),
+        showReactions = state.showReactions,
         canWrite = state.canWrite,
         canPinMessages = canPinMessages,
         isPinned = selectedMessage.id == state.pinnedMessage?.id,

--- a/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/MessageOptionsMenu.kt
+++ b/presentation/src/main/java/org/monogram/presentation/features/stickers/ui/menu/MessageOptionsMenu.kt
@@ -190,6 +190,7 @@ fun MessageOptionsMenu(
     onSelect: () -> Unit = {},
     onCopyLink: () -> Unit,
     onCopy: () -> Unit,
+    showReactions: Boolean = true,
     onSaveToDownloads: () -> Unit = {},
     onReaction: (String) -> Unit = {},
     onComments: () -> Unit = {},
@@ -310,9 +311,13 @@ fun MessageOptionsMenu(
         )
     }
 
-    LaunchedEffect(message.chatId, message.id) {
-        availableReactions = null
-        availableReactions = emojiRepository.getMessageAvailableReactions(message.chatId, message.id)
+    LaunchedEffect(message.chatId, message.id, showReactions) {
+        if (showReactions) {
+            availableReactions = null
+            availableReactions = emojiRepository.getMessageAvailableReactions(message.chatId, message.id)
+        } else {
+            availableReactions = emptyList()
+        }
     }
 
     fun animateOutAndDismiss(action: (() -> Unit)? = null) {
@@ -660,20 +665,22 @@ fun MessageOptionsMenu(
                             showViewsInfo = showViewsInfo
                         )
 
-                        ReactionsRow(
-                            message = message,
-                            availableReactions = availableReactions,
-                            suppressAppearanceAnimation = suppressNextReactionsAppearanceAnimation,
-                            onAppearanceAnimationConsumed = {
-                                suppressNextReactionsAppearanceAnimation = false
-                            },
-                            onReactionsChanged = { reactionCount ->
-                                hasReactionsInMessage = reactionCount > 0
-                            },
-                            onReaction = { reaction ->
-                                animateOutAndDismiss { onReaction(reaction) }
-                            }
-                        )
+                        if (showReactions) {
+                            ReactionsRow(
+                                message = message,
+                                availableReactions = availableReactions,
+                                suppressAppearanceAnimation = suppressNextReactionsAppearanceAnimation,
+                                onAppearanceAnimationConsumed = {
+                                    suppressNextReactionsAppearanceAnimation = false
+                                },
+                                onReactionsChanged = { reactionCount ->
+                                    hasReactionsInMessage = reactionCount > 0
+                                },
+                                onReaction = { reaction ->
+                                    animateOutAndDismiss { onReaction(reaction) }
+                                }
+                            )
+                        }
 
                         if (sections.hasForwardAction) {
                             InternalMenuOptionItem(

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
@@ -95,6 +95,8 @@ interface ChatSettingsComponent {
     fun onCompressVideosChanged(enabled: Boolean)
     fun onChatListMessageLinesChanged(lines: Int)
     fun onShowChatListPhotosChanged(enabled: Boolean)
+    fun onMessageOptionsOnSingleTapEnabledChanged(enabled: Boolean)
+    fun onShowReactionsChanged(enabled: Boolean)
 
     data class State(
         val fontSize: Float = 16f,
@@ -164,6 +166,8 @@ interface ChatSettingsComponent {
         val compressVideos: Boolean = true,
         val chatListMessageLines: Int = 1,
         val showChatListPhotos: Boolean = true,
+        val messageOptionsOnSingleTapEnabled: Boolean = true,
+        val showReactions: Boolean = true,
         val isInstalledFromGooglePlay: Boolean = true
     )
 }
@@ -242,6 +246,8 @@ class DefaultChatSettingsComponent(
             compressVideos = appPreferences.compressVideos.value,
             chatListMessageLines = appPreferences.chatListMessageLines.value,
             showChatListPhotos = appPreferences.showChatListPhotos.value,
+            messageOptionsOnSingleTapEnabled = appPreferences.messageOptionsOnSingleTapEnabled.value,
+            showReactions = appPreferences.showReactions.value,
             isInstalledFromGooglePlay = distrManager.isInstalledFromGooglePlay()
         )
     )
@@ -594,6 +600,12 @@ class DefaultChatSettingsComponent(
         appPreferences.showChatListPhotos
             .onEach { enabled ->
                 _state.update { it.copy(showChatListPhotos = enabled) }
+            }
+            .launchIn(scope)
+
+        appPreferences.messageOptionsOnSingleTapEnabled
+            .onEach { enabled ->
+                _state.update { it.copy(messageOptionsOnSingleTapEnabled = enabled) }
             }
             .launchIn(scope)
 
@@ -1217,6 +1229,14 @@ class DefaultChatSettingsComponent(
 
     override fun onShowChatListPhotosChanged(enabled: Boolean) {
         appPreferences.setShowChatListPhotos(enabled)
+    }
+
+    override fun onMessageOptionsOnSingleTapEnabledChanged(enabled: Boolean) {
+        appPreferences.setMessageOptionsOnSingleTapEnabled(enabled)
+    }
+
+    override fun onShowReactionsChanged(enabled: Boolean) {
+        appPreferences.setShowReactions(enabled)
     }
 
     private fun shiftHue(color: Int, delta: Float): Int {

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsComponent.kt
@@ -95,7 +95,6 @@ interface ChatSettingsComponent {
     fun onCompressVideosChanged(enabled: Boolean)
     fun onChatListMessageLinesChanged(lines: Int)
     fun onShowChatListPhotosChanged(enabled: Boolean)
-    fun onMessageOptionsOnSingleTapEnabledChanged(enabled: Boolean)
     fun onShowReactionsChanged(enabled: Boolean)
 
     data class State(
@@ -166,7 +165,6 @@ interface ChatSettingsComponent {
         val compressVideos: Boolean = true,
         val chatListMessageLines: Int = 1,
         val showChatListPhotos: Boolean = true,
-        val messageOptionsOnSingleTapEnabled: Boolean = true,
         val showReactions: Boolean = true,
         val isInstalledFromGooglePlay: Boolean = true
     )
@@ -246,7 +244,6 @@ class DefaultChatSettingsComponent(
             compressVideos = appPreferences.compressVideos.value,
             chatListMessageLines = appPreferences.chatListMessageLines.value,
             showChatListPhotos = appPreferences.showChatListPhotos.value,
-            messageOptionsOnSingleTapEnabled = appPreferences.messageOptionsOnSingleTapEnabled.value,
             showReactions = appPreferences.showReactions.value,
             isInstalledFromGooglePlay = distrManager.isInstalledFromGooglePlay()
         )
@@ -600,12 +597,6 @@ class DefaultChatSettingsComponent(
         appPreferences.showChatListPhotos
             .onEach { enabled ->
                 _state.update { it.copy(showChatListPhotos = enabled) }
-            }
-            .launchIn(scope)
-
-        appPreferences.messageOptionsOnSingleTapEnabled
-            .onEach { enabled ->
-                _state.update { it.copy(messageOptionsOnSingleTapEnabled = enabled) }
             }
             .launchIn(scope)
 
@@ -1229,10 +1220,6 @@ class DefaultChatSettingsComponent(
 
     override fun onShowChatListPhotosChanged(enabled: Boolean) {
         appPreferences.setShowChatListPhotos(enabled)
-    }
-
-    override fun onMessageOptionsOnSingleTapEnabledChanged(enabled: Boolean) {
-        appPreferences.setMessageOptionsOnSingleTapEnabled(enabled)
     }
 
     override fun onShowReactionsChanged(enabled: Boolean) {

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
@@ -935,6 +935,24 @@ fun ChatSettingsContent(component: ChatSettingsComponent) {
                     enabled = state.showLinkPreviews,
                     onCheckedChange = component::onFixLinkPreviewsChanged
                 )
+                SettingsSwitchTile(
+                    icon = Icons.Rounded.Gesture,
+                    title = stringResource(R.string.message_options_single_tap_title),
+                    subtitle = stringResource(R.string.message_options_single_tap_subtitle),
+                    checked = state.messageOptionsOnSingleTapEnabled,
+                    iconColor = greenColor,
+                    position = ItemPosition.MIDDLE,
+                    onCheckedChange = component::onMessageOptionsOnSingleTapEnabledChanged
+                )
+                SettingsSwitchTile(
+                    icon = Icons.Rounded.EmojiEmotions,
+                    title = stringResource(R.string.show_reactions_title),
+                    subtitle = stringResource(R.string.show_reactions_subtitle),
+                    checked = state.showReactions,
+                    iconColor = orangeColor,
+                    position = ItemPosition.MIDDLE,
+                    onCheckedChange = component::onShowReactionsChanged
+                )
                 if (isTablet) {
                     SettingsSwitchTile(
                         icon = Icons.Rounded.TabletAndroid,

--- a/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
+++ b/presentation/src/main/java/org/monogram/presentation/settings/chatSettings/ChatSettingsContent.kt
@@ -935,15 +935,7 @@ fun ChatSettingsContent(component: ChatSettingsComponent) {
                     enabled = state.showLinkPreviews,
                     onCheckedChange = component::onFixLinkPreviewsChanged
                 )
-                SettingsSwitchTile(
-                    icon = Icons.Rounded.Gesture,
-                    title = stringResource(R.string.message_options_single_tap_title),
-                    subtitle = stringResource(R.string.message_options_single_tap_subtitle),
-                    checked = state.messageOptionsOnSingleTapEnabled,
-                    iconColor = greenColor,
-                    position = ItemPosition.MIDDLE,
-                    onCheckedChange = component::onMessageOptionsOnSingleTapEnabledChanged
-                )
+
                 SettingsSwitchTile(
                     icon = Icons.Rounded.EmojiEmotions,
                     title = stringResource(R.string.show_reactions_title),

--- a/presentation/src/main/res/values/string.xml
+++ b/presentation/src/main/res/values/string.xml
@@ -974,6 +974,10 @@
     <string name="show_link_previews_subtitle">Display previews for links in messages</string>
     <string name="fix_link_previews_title">Fix Link Previews</string>
     <string name="fix_link_previews_subtitle">Use alternative previews for problematic X, Twitter, and Bluesky links</string>
+    <string name="message_options_single_tap_title">Open Options on Single Tap</string>
+    <string name="message_options_single_tap_subtitle">Enable opening the message options menu with a single tap. If disabled, a long press is required.</string>
+    <string name="show_reactions_title">Show Reactions</string>
+    <string name="show_reactions_subtitle">Show quick reactions on messages</string>
     <string name="drag_to_back_title">Drag to Back</string>
     <string name="drag_to_back_subtitle">Swipe from left edge to go back</string>
     <string name="tablet_interface_title">Tablet Interface</string>


### PR DESCRIPTION
### What this does
Fixes #279  by adding a new chat setting to toggle message reactions on/off. 

Instead of adding an `if (showReactions)` check inside every single message bubble component (text, photo, sticker, audio, etc.), I wired the new `showReactions` preference down to `MessageAppearanceConfig`. Then, at the root level (`MessageBubbleContainer` and `AlbumMessageBubbleContainer`), we just pass down a copy of the message with `reactions = emptyList()` if the setting is toggled off. 

Since the `MessageReactionsView` already has an early return for empty reaction lists, this cleanly hides them across all bubble types without cluttering the individual components.

### Changes
- Added `showReactions` to `AppPreferences` (defaults to true).
- Added a switch tile for it in Chat Settings, under the "Open Options on Single Tap" setting.
- Intercepted the `MessageModel` in bubble containers to conditionally strip reactions before they reach the child views.
